### PR TITLE
shared_app.pri: Generalize the FreeBSD mkspecs being matched.

### DIFF
--- a/shared_app.pri
+++ b/shared_app.pri
@@ -40,7 +40,7 @@ linux-g++ {
     LIBS += -lGLU
 }
 
-freebsd-g++ {
+freebsd-* {
     LIBS += -lGLU -lexecinfo
 }
 


### PR DESCRIPTION
"freebsd-g++" restricts those common settings to a single mkspec that matches
the base system's outdated GCC 4.2 and excludes all the mkspecs for other GCC
versions and clang that are also shipped on FreeBSD.
