### PR TITLE
Added an option to display dimension arrows as circles

### DIFF
--- a/scripts/Edit/DrawingPreferences/DimensionSettings/DimensionSettings.js
+++ b/scripts/Edit/DrawingPreferences/DimensionSettings/DimensionSettings.js
@@ -551,11 +551,16 @@ DimensionSettings.savePreferences = function(pageWidget, calledByPrefDialog, doc
         document.setKnownVariable(RS.DIMTSZ, document.getKnownVariable(RS.DIMASZ));
         //document.setKnownVariable(RS.DIMBLK, "ArchTick");
     }
+    else if (widgets["Dot"].checked) {
+        document.setKnownVariable(RS.DIMTSZ, -document.getKnownVariable(RS.DIMASZ));
+        //document.setKnownVariable(RS.DIMBLK, "Dot");
+    }
     else {
         document.setKnownVariable(RS.DIMTSZ, 0.0);
         //document.setKnownVariable(RS.DIMBLK, "");
     }
     widgets["ArchitecturalTick"].setProperty("Saved", true);
+    widgets["Dot"].setProperty("Saved", true);
     widgets["Arrow"].setProperty("Saved", true);
 
     //qDebug("linear format: ", );

--- a/scripts/Edit/DrawingPreferences/DimensionSettings/PreferencesPage.ui
+++ b/scripts/Edit/DrawingPreferences/DimensionSettings/PreferencesPage.ui
@@ -279,6 +279,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QRadioButton" name="Dot">
+         <property name="text">
+          <string>Dot</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="horizontalSpacer">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>

--- a/src/entity/RDimensionData.cpp
+++ b/src/entity/RDimensionData.cpp
@@ -18,7 +18,7 @@
  */
 #include "RDimensionData.h"
 #include "RUnit.h"
-
+#include "RCircle.h"
 
 
 RDimensionData::RDimensionData(RDocument* document) :
@@ -287,6 +287,17 @@ bool RDimensionData::useArchTick() const {
     return ret;
 }
 
+bool RDimensionData::useDot() const {
+    bool ret = false;
+
+    if (document!=NULL) {
+        ret = document->getKnownVariable(RS::DIMBLK, "").toString().toLower()=="dot" ||
+              document->getKnownVariable(RS::DIMTSZ, 0.0).toDouble() < -RS::PointTolerance;
+    }
+
+    return ret;
+}
+
 bool RDimensionData::hasCustomTextPosition() const {
     return !autoTextPos;
 }
@@ -386,6 +397,12 @@ QList<QSharedPointer<RShape> > RDimensionData::getArrow(
         line.rotate(direction, RVector(0,0));
         line.move(position);
         ret.append(QSharedPointer<RLine>(new RLine(line)));
+    }
+    
+    // dot:
+    else if (useDot()) {
+        RCircle circle(position, arrowSize/3);
+        ret.append(QSharedPointer<RCircle>(new RCircle(circle)));
     }
 
     // standard arrow:

--- a/src/entity/RDimensionData.h
+++ b/src/entity/RDimensionData.h
@@ -136,6 +136,7 @@ public:
     double getDimgap() const;
     double getDimtxt() const;
     bool useArchTick() const;
+    bool useDot() const;
     bool hasCustomTextPosition() const;
     void setCustomTextPosition(bool on);
 


### PR DESCRIPTION
Hi Andrew,
The following commit adds a new option to the dimension preferences screen, aside the existing "arrow" and "arch tick" options, to show dimension arrows as dots (pretty common for architecture work). If it interests you, feel free to merge (or wait until I solve what is here below), otherwise, just discard it, no problem with that!

Currently, everything works OK, but the dots are displayed as small circles, because I couldn't find any existing way to display them as filled dots. I believe that feature doesn't exist yet in qcad... Can you confirm this to me? If it is true, could you indicate me roughly the way so I could add that?

Also, I saw that qcad currently checks if a variable is zero or positive to distinguish between arrow and arch tick, I extended that by setting it to a negative value for the dot option, this doesn't seem to cause any problem, but it might be wrong anyway, please tell me if there is a better way.

Cheers
Yorik
