### PR TITLE
Build breaks due to typo. It is "QUiLoader" not "QUILoader"

### DIFF
--- a/src/3rdparty/qt-labs-qtscriptgenerator-5.4.1/generated_cpp/com_trolltech_qt_uitools/qtscript_QUiLoader.cpp
+++ b/src/3rdparty/qt-labs-qtscriptgenerator-5.4.1/generated_cpp/com_trolltech_qt_uitools/qtscript_QUiLoader.cpp
@@ -6,7 +6,7 @@
 #include <QMetaObject>
 #include <__package_shared.h>
 
-#include <QUILoader>
+#include <QUiLoader>
 #include <QVariant>
 #include <QtWidgets/QAction>
 #include <QtWidgets/QActionGroup>
@@ -18,7 +18,7 @@
 #include <QList>
 #include <QObject>
 #include <QStringList>
-#include <QUILoader>
+#include <QUiLoader>
 #include <QtWidgets/QWidget>
 
 #include "qtscriptshell_QUiLoader.h"

--- a/src/3rdparty/qt-labs-qtscriptgenerator-5.4.1/generated_cpp/com_trolltech_qt_uitools/qtscriptshell_QUiLoader.cpp
+++ b/src/3rdparty/qt-labs-qtscriptgenerator-5.4.1/generated_cpp/com_trolltech_qt_uitools/qtscriptshell_QUiLoader.cpp
@@ -12,7 +12,7 @@
 #include <QList>
 #include <QObject>
 #include <QStringList>
-#include <QUILoader>
+#include <QUiLoader>
 #include <QEvent>
 #include <QtWidgets/QWidget>
 


### PR DESCRIPTION
At least with 5.4.1 I needed to correct the spelling.