### PR TITLE
fix endless build problem

### DIFF
--- a/qcad.pro
+++ b/qcad.pro
@@ -13,7 +13,7 @@ win32 {
     }
 }
 else {
-    SUBDIRS += $$system("ls -d ../qcad?* 2>/dev/null | grep -v qcadmobile")
+    SUBDIRS += $$system("ls -d ../qcad?* 2>/dev/null | grep -v $(basename $(pwd)) | grep -v qcadmobile")
 }
 
 !r_mobile {


### PR DESCRIPTION
This patch adds a filter to exclude current directory from SUBDIRS list (qcad.pro) even it does match to the pattern (../qcad?*).
Note: including current directory to SUBDIRS produce an endless recursion during make.

Example to reproduce problem:

```
git clone --depth 1 -b v3.16.7.0 https://github.com/qcad/qcad.git qcad-3.16.7.0
cd qcad-3.16.7.0
qmake
make # <-- will build current directory, then ../qcad-3.16.7.0, then ../qcad-3.16.7.0, …
```