### PR TITLE
Use std::istream and add clockwise to DL_ArcData.

### DIFF
--- a/src/3rdparty/dxflib/src/dl_dxf.cpp
+++ b/src/3rdparty/dxflib/src/dl_dxf.cpp
@@ -129,14 +129,14 @@ bool DL_Dxf::in(const std::string& file, DL_CreationInterface* creationInterface
 /**
  * Reads a DXF file from an existing stream.
  *
- * @param stream The string stream.
+ * @param stream The input stream.
  * @param creationInterface
  *      Pointer to the class which takes care of the entities in the file.
  *
  * @retval true If \p file could be opened.
  * @retval false If \p file could not be opened.
  */
-bool DL_Dxf::in(std::stringstream& stream,
+bool DL_Dxf::in(std::istream& stream,
                 DL_CreationInterface* creationInterface) {
     
     if (stream.good()) {
@@ -193,9 +193,9 @@ bool DL_Dxf::readDxfGroups(FILE *fp, DL_CreationInterface* creationInterface) {
 
 
 /**
- * Same as above but for stringstreams.
+ * Same as above but for istreams.
  */
-bool DL_Dxf::readDxfGroups(std::stringstream& stream,
+bool DL_Dxf::readDxfGroups(std::istream& stream,
                            DL_CreationInterface* creationInterface) {
 
     static int line = 1;
@@ -263,10 +263,10 @@ bool DL_Dxf::getStrippedLine(std::string& s, unsigned int size, FILE *fp, bool s
 
 
 /**
- * Same as above but for stringstreams.
+ * Same as above but for istream.
  */
 bool DL_Dxf::getStrippedLine(std::string &s, unsigned int size,
-                            std::stringstream& stream, bool stripSpace) {
+                            std::istream& stream, bool stripSpace) {
 
     if (!stream.eof()) {
         // Only the useful part of the line
@@ -1113,7 +1113,8 @@ void DL_Dxf::addArc(DL_CreationInterface* creationInterface) {
                  getRealValue(30, 0.0),
                  getRealValue(40, 0.0),
                  getRealValue(50, 0.0),
-                 getRealValue(51, 0.0));
+                 getRealValue(51, 0.0),
+                 values[230].empty() || 0 < toReal(values[230]));
 
     creationInterface->addArc(d);
 }

--- a/src/3rdparty/dxflib/src/dl_dxf.h
+++ b/src/3rdparty/dxflib/src/dl_dxf.h
@@ -131,12 +131,12 @@ public:
     static bool getStrippedLine(std::string& s, unsigned int size,
                                FILE* stream, bool stripSpace = true);
     
-    bool readDxfGroups(std::stringstream& stream,
+    bool readDxfGroups(std::istream& stream,
                        DL_CreationInterface* creationInterface);
-    bool in(std::stringstream &stream,
+    bool in(std::istream &stream,
             DL_CreationInterface* creationInterface);
     static bool getStrippedLine(std::string& s, unsigned int size,
-                               std::stringstream& stream, bool stripSpace = true);
+                               std::istream& stream, bool stripSpace = true);
 
     static bool stripWhiteSpace(char** s, bool stripSpaces = true);
 

--- a/src/3rdparty/dxflib/src/dl_entities.h
+++ b/src/3rdparty/dxflib/src/dl_entities.h
@@ -319,7 +319,8 @@ struct DXFLIB_EXPORT DL_ArcData {
      */
     DL_ArcData(double acx, double acy, double acz,
                double aRadius,
-               double aAngle1, double aAngle2) {
+               double aAngle1, double aAngle2,
+               bool aClockwise) {
 
         cx = acx;
         cy = acy;
@@ -327,6 +328,7 @@ struct DXFLIB_EXPORT DL_ArcData {
         radius = aRadius;
         angle1 = aAngle1;
         angle2 = aAngle2;
+        clockwise = aClockwise;
     }
 
     /*! X Coordinate of center point. */
@@ -342,6 +344,9 @@ struct DXFLIB_EXPORT DL_ArcData {
     double angle1;
     /*! Endangle of arc in degrees. */
     double angle2;
+
+    /*! Rotation direction of arc. */
+    bool clockwise;
 };
 
 


### PR DESCRIPTION
 1. Use ``std::istream`` instead of ``std::stringstream``.  It is not necessary to restrict to ``std::stringstream``.
 2. Added ``clockwise`` to ``DL_ArcData``.

These changes are needed by http://github.com/CauldronDevelopmentLLC/CAMotics/.