### PR TITLE
Don't link against Qt

### DIFF
--- a/src/3rdparty/dxflib/dxflib.pro
+++ b/src/3rdparty/dxflib/dxflib.pro
@@ -26,4 +26,5 @@ SOURCES = \
 TARGET = dxflib
 TEMPLATE = lib
 CONFIG += staticlib
+CONFIG -= qt
 DEFINES += DXFLIB_LIBRARY


### PR DESCRIPTION
When building the project outside the QCad it is making the library dependent on Qt.