### PR TITLE
Add Misc - Select - SelectByColor command

### DIFF
--- a/scripts/Misc/MiscSelect/SelectByColor/SelectByColor.js
+++ b/scripts/Misc/MiscSelect/SelectByColor/SelectByColor.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2011-2018 by RibbonSoft, GmbH. All rights reserved.
+ *
+ * This file is part of the QCAD project.
+ *
+ * QCAD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QCAD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QCAD.
+ */
+
+include("scripts/EAction.js");
+
+/**
+ * \class SelectByColor
+ * \ingroup ecma_misc_select
+ *
+ * \brief Selects entities by their color.
+ */
+function SelectByColor(guiAction) {
+    EAction.call(this, guiAction);
+}
+
+SelectByColor.prototype = new EAction();
+SelectByColor.includeBasePath = includeBasePath;
+
+SelectByColor.prototype.beginEvent = function() {
+    EAction.prototype.beginEvent.call(this);
+
+    var di = this.getDocumentInterface();
+    var document = this.getDocument();
+    var selected = document.querySelectedEntities();
+    var desiredColor = undefined;
+    var name;
+    var localName;
+
+    for (var e = 0; e < selected.length; ++e) {
+	var entityId = selected[e];
+	var entity = document.queryEntityDirect(entityId);
+	var color = entity.getDisplayColor();
+	localName = color.getName();
+	name = color.name();
+	if (typeof(desiredColor) == 'undefined') {
+	    desiredColor = name;
+	} else {
+	    if (name != desiredColor) {
+		desiredColor = undefined;
+		break;
+	    }
+	}
+    }
+
+    if (typeof(desiredColor) == 'undefined') {
+        EAction.handleUserWarning(qsTr("Select one or more objects only of the desired color"));
+    } else {
+	var visible = document.queryAllVisibleEntities();
+        var entityIdsToSelect = [];
+	for (var e = 0; e < visible.length; ++e) {
+	    var entityId = visible[e];
+            var entity = document.queryEntity(entityId);
+	    var color = entity.getDisplayColor();
+	    name = color.name();
+	    if (name == desiredColor) {
+                entityIdsToSelect.push(entityId);
+            }
+        }
+        if (entityIdsToSelect.length!==0) {
+            di.selectEntities(entityIdsToSelect);
+        }
+        EAction.handleUserMessage(qsTr("Selected all visible entities of color") + " " + localName);
+    }
+
+    EAction.activateMainWindow();
+    this.terminate();
+};

--- a/scripts/Misc/MiscSelect/SelectByColor/SelectByColor.pro
+++ b/scripts/Misc/MiscSelect/SelectByColor/SelectByColor.pro
@@ -1,0 +1,2 @@
+NAME = $${TARGET} 
+SOURCES = $${TARGET}.js $${TARGET}Init.js

--- a/scripts/Misc/MiscSelect/SelectByColor/SelectByColorInit.js
+++ b/scripts/Misc/MiscSelect/SelectByColor/SelectByColorInit.js
@@ -1,0 +1,10 @@
+function init(basePath) {
+    var action = new RGuiAction(qsTranslate("SelectByColor", "By Color"), RMainWindowQt.getMainWindow());
+    action.setRequiresDocument(true);
+    action.setScriptFile(basePath + "/SelectByColor.js");
+    action.setStatusTip(qsTr("Select all objects of a color"));
+    action.setDefaultShortcut(new QKeySequence("t,f"));
+    action.setGroupSortOrder(73100);
+    action.setSortOrder(400);
+    action.setWidgetNames(["MiscSelectMenu", "MiscSelectToolBar", "MiscSelectToolsPanel"]);
+}


### PR DESCRIPTION
Selects all visible entities of the same color as a single selected entity.  The use case that motivated development of this command was to separate into multiple layers the entities of an SVG Import that all go into layer 0 even though they may have originated as multiple layers using different colors in the tool where the drawing was created.

Please advise if the init parameters should be adjusted.