### PR TITLE
Recognize OpenBSD

### DIFF
--- a/scripts/Help/About/About.js
+++ b/scripts/Help/About/About.js
@@ -451,6 +451,9 @@ About.prototype.initAboutSystem = function(textEdit) {
     if (RS.getSystemId()==="linux") {
         text += "Linux";
     }
+    if (RS.getSystemId()==="openbsd") {
+        text += "OpenBSD";
+    }
     text += "\nOS version: " + RSettings.getOSVersion();
 
     text += "\n";

--- a/scripts/Widgets/CommandLine/CommandLine.js
+++ b/scripts/Widgets/CommandLine/CommandLine.js
@@ -478,6 +478,9 @@ CommandLine.init = function(basePath) {
     case "linux":
         system = "Linux";
         break;
+    case "openbsd":
+        system = "OpenBSD";
+        break;
     }
     EAction.handleUserMessage(
                 "%1 %2 / %3 %4"

--- a/src/core/RSPlatform.cpp
+++ b/src/core/RSPlatform.cpp
@@ -37,13 +37,13 @@
 #endif
 
 /**
- * \return Unique combination of system ID (linux, osx, win) and host name.
+ * \return Unique combination of system ID (linux, openbsd, osx, win) and host name.
  * E.g. "linux_vertigo". Used for test data that may differ on different machines.
  */
 QString RS::getHostId() {
     return QString("%1_%2")
             .arg(getSystemId())
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
     .arg(getenv("HOSTNAME"));
 #elif defined(Q_OS_MAC)
     // environment variable HOSTNAME not exported on OS X by default:
@@ -56,11 +56,13 @@ QString RS::getHostId() {
 }
 
 /**
- * \return Unique system ID ("linux", "osx", "win").
+ * \return Unique system ID ("linux", "openbsd", "osx", "win").
  */
 QString RS::getSystemId() {
 #if defined(Q_OS_LINUX)
     return "linux";
+#elif defined(Q_OS_OPENBSD)
+    return "openbsd";
 #elif defined(Q_OS_MAC)
     return "osx";
 #elif defined(Q_OS_WIN)


### PR DESCRIPTION
QCAD works fine on OpenBSD and is part of the offical ports tree (https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/cad/qcad/). So recognize OpenBSD as supported platform.