### PR TITLE
fix building with QT 5.15

### DIFF
--- a/src/gui/RRulerQt.h
+++ b/src/gui/RRulerQt.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2011-2018 by Andrew Mustun. All rights reserved.
- * 
+ *
  * This file is part of the QCAD project.
  *
  * QCAD is free software: you can redistribute it and/or modify
@@ -24,6 +24,7 @@
 
 #include <QFrame>
 #include <QMetaType>
+#include <QPainterPath>
 
 #include "RCoordinateListener.h"
 #include "RRuler.h"


### PR DESCRIPTION
When building with QT 5.15 you get the following error:

release/../RRulerQt.h:71:18: error: field ‘cursorArrow’ has incomplete type ‘QPainterPath’
   71 |     QPainterPath cursorArrow;
      |                  ^~~~~~~~~~~
In file included from /usr/include/qt/QtGui/qbrush.h:49,
                 from /usr/include/qt/QtGui/qpalette.h:46,
                 from /usr/include/qt/QtWidgets/qwidget.h:48,
                 from /usr/include/qt/QtWidgets/qframe.h:44,
                 from /usr/include/qt/QtWidgets/QFrame:1,
                 from release/../RRulerQt.h:25,
                 from release/moc_RRulerQt.cpp:10:

If we include QPainterPath qcad builds just fine.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>