### PR TITLE
Improve the script path processing.

### DIFF
--- a/scripts/Help/About/AboutCredits.js
+++ b/scripts/Help/About/AboutCredits.js
@@ -49,7 +49,8 @@ var credits =
         [ "Tamas Tevesz",     "Port to FreeBSD<br>" +
                               "Various improvements and fixes<br>"
                               ],
-        [ "Weston Schmidt",   "Draw > Dimension > Per-dimension scaling<br>"
+        [ "Weston Schmidt",   "Draw > Dimension > Per-dimension scaling<br>" +
+                              "Script inclusion path improvements<br>"
                               ],
     ],
     [


### PR DESCRIPTION
This change adds the ability to point to a script file that includes
other script files the same as the script library that comes with QCAD.
The included files are included based on the following search order:
 1. The initial script's path
 2. The local script directory path (platform dependent)
 3. The script directory next to the executable
 4. The built in script files via a library

To ensure consistency on possibly overwritten files in different
locations, the list duplication removal function was replaced with a
version that maintains the order of the list.