### PR TITLE
Fix system-wide .dxf typo  

### DIFF
--- a/examples/flange.dxf
+++ b/examples/flange.dxf
@@ -1493,7 +1493,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/libraries/templates/metric/din_a3_m_landscape.dxf
+++ b/libraries/templates/metric/din_a3_m_landscape.dxf
@@ -1491,7 +1491,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/libraries/templates/metric/din_a3_m_landscape_bw.dxf
+++ b/libraries/templates/metric/din_a3_m_landscape_bw.dxf
@@ -1491,7 +1491,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/libraries/templates/metric/din_a3_mm_landscape.dxf
+++ b/libraries/templates/metric/din_a3_mm_landscape.dxf
@@ -1491,7 +1491,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/libraries/templates/metric/din_a3_mm_portrait.dxf
+++ b/libraries/templates/metric/din_a3_mm_portrait.dxf
@@ -1491,7 +1491,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/libraries/templates/metric/iso_en_a0.dxf
+++ b/libraries/templates/metric/iso_en_a0.dxf
@@ -3105,7 +3105,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/libraries/templates/metric/iso_en_a1.dxf
+++ b/libraries/templates/metric/iso_en_a1.dxf
@@ -3105,7 +3105,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/libraries/templates/metric/iso_en_a2.dxf
+++ b/libraries/templates/metric/iso_en_a2.dxf
@@ -3105,7 +3105,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/libraries/templates/metric/iso_en_a3.dxf
+++ b/libraries/templates/metric/iso_en_a3.dxf
@@ -3261,7 +3261,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/libraries/templates/metric/iso_en_a4.dxf
+++ b/libraries/templates/metric/iso_en_a4.dxf
@@ -3261,7 +3261,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/libraries/templates/metric/iso_en_a4_metric_landscape_aec.dxf
+++ b/libraries/templates/metric/iso_en_a4_metric_landscape_aec.dxf
@@ -3257,7 +3257,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/libraries/templates/metric/iso_en_a4_metric_portrait_aec.dxf
+++ b/libraries/templates/metric/iso_en_a4_metric_portrait_aec.dxf
@@ -2299,7 +2299,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Block/AddBlock/Tests/required/AddBlockTest00_000.dxf
+++ b/scripts/Block/AddBlock/Tests/required/AddBlockTest00_000.dxf
@@ -2453,7 +2453,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Block/CreateBlock/Tests/required/CreateBlockTest00_000.dxf
+++ b/scripts/Block/CreateBlock/Tests/required/CreateBlockTest00_000.dxf
@@ -2453,7 +2453,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Block/CreateBlock/Tests/required/CreateBlockTest01_000.dxf
+++ b/scripts/Block/CreateBlock/Tests/required/CreateBlockTest01_000.dxf
@@ -2453,7 +2453,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Block/CreateBlock/Tests/required/CreateBlockTest02_000.dxf
+++ b/scripts/Block/CreateBlock/Tests/required/CreateBlockTest02_000.dxf
@@ -2453,7 +2453,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Block/CreateBlock/Tests/required/CreateBlockTest02_001.dxf
+++ b/scripts/Block/CreateBlock/Tests/required/CreateBlockTest02_001.dxf
@@ -2453,7 +2453,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Block/CreateBlock/Tests/required/CreateBlockTest02_002.dxf
+++ b/scripts/Block/CreateBlock/Tests/required/CreateBlockTest02_002.dxf
@@ -2453,7 +2453,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Block/EditFromReference/Tests/required/EditFromReferenceTest00_000.dxf
+++ b/scripts/Block/EditFromReference/Tests/required/EditFromReferenceTest00_000.dxf
@@ -2453,7 +2453,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Circle/Circle2TP/Tests/required/Circle2TPTest00_000.dxf
+++ b/scripts/Draw/Circle/Circle2TP/Tests/required/Circle2TPTest00_000.dxf
@@ -3059,7 +3059,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Circle/CircleCR/Tests/required/CircleCRTest00_000.dxf
+++ b/scripts/Draw/Circle/CircleCR/Tests/required/CircleCRTest00_000.dxf
@@ -2985,7 +2985,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Dimension/DimAligned/Tests/required/DimAlignedTest00_000.dxf
+++ b/scripts/Draw/Dimension/DimAligned/Tests/required/DimAlignedTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Dimension/DimAngular/Tests/required/DimAngularTest00_000.dxf
+++ b/scripts/Draw/Dimension/DimAngular/Tests/required/DimAngularTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Dimension/DimDiametric/Tests/required/DimDiametricTest00_000.dxf
+++ b/scripts/Draw/Dimension/DimDiametric/Tests/required/DimDiametricTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Dimension/DimHorizontal/Tests/required/DimHorizontalTest00_000.dxf
+++ b/scripts/Draw/Dimension/DimHorizontal/Tests/required/DimHorizontalTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Dimension/DimOrdinate/Tests/required/DimOrdinateTest00_000.dxf
+++ b/scripts/Draw/Dimension/DimOrdinate/Tests/required/DimOrdinateTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Dimension/DimRadial/Tests/required/DimRadialTest00_000.dxf
+++ b/scripts/Draw/Dimension/DimRadial/Tests/required/DimRadialTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Dimension/DimRotated/Tests/required/DimRotatedTest00_000.dxf
+++ b/scripts/Draw/Dimension/DimRotated/Tests/required/DimRotatedTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Dimension/DimVertical/Tests/required/DimVerticalTest00_000.dxf
+++ b/scripts/Draw/Dimension/DimVertical/Tests/required/DimVerticalTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Dimension/Leader/Tests/required/LeaderTest00_000.dxf
+++ b/scripts/Draw/Dimension/Leader/Tests/required/LeaderTest00_000.dxf
@@ -2837,7 +2837,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Ellipse/EllipseArcCPPA/Tests/required/EllipseArcCPPATest00_000.dxf
+++ b/scripts/Draw/Ellipse/EllipseArcCPPA/Tests/required/EllipseArcCPPATest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Ellipse/EllipseOffset/Tests/required/EllipseOffsetTest00_000.dxf
+++ b/scripts/Draw/Ellipse/EllipseOffset/Tests/required/EllipseOffsetTest00_000.dxf
@@ -1757,7 +1757,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Ellipse/EllipseOffsetThrough/Tests/required/EllipseOffsetThroughTest00_000.dxf
+++ b/scripts/Draw/Ellipse/EllipseOffsetThrough/Tests/required/EllipseOffsetThroughTest00_000.dxf
@@ -1757,7 +1757,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Hatch/HatchFromSelection/Tests/data/hatch_block_polyline.dxf
+++ b/scripts/Draw/Hatch/HatchFromSelection/Tests/data/hatch_block_polyline.dxf
@@ -2367,7 +2367,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Hatch/HatchFromSelection/Tests/data/hatch_blocks.dxf
+++ b/scripts/Draw/Hatch/HatchFromSelection/Tests/data/hatch_blocks.dxf
@@ -2041,7 +2041,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Hatch/HatchFromSelection/Tests/data/hatch_two_blocks.dxf
+++ b/scripts/Draw/Hatch/HatchFromSelection/Tests/data/hatch_two_blocks.dxf
@@ -3343,7 +3343,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest00_000.dxf
+++ b/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest01_000.dxf
+++ b/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest01_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest02_000.dxf
+++ b/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest02_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest03_000.dxf
+++ b/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest03_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest04_000.dxf
+++ b/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest04_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest05_000.dxf
+++ b/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest05_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest06_000.dxf
+++ b/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest06_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest07_000.dxf
+++ b/scripts/Draw/Hatch/HatchFromSelection/Tests/required/HatchFromSelectionTest07_000.dxf
@@ -3069,7 +3069,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Line/LineParallel/Tests/required/LineParallelTest01_000.dxf
+++ b/scripts/Draw/Line/LineParallel/Tests/required/LineParallelTest01_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Line/LineParallelThrough/Tests/required/LineParallelThroughTest01_000.dxf
+++ b/scripts/Draw/Line/LineParallelThrough/Tests/required/LineParallelThroughTest01_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Draw/Shape/ShapePolygonPP/Tests/required/ShapePolygonPPTest00_000.dxf
+++ b/scripts/Draw/Shape/ShapePolygonPP/Tests/required/ShapePolygonPPTest00_000.dxf
@@ -2985,7 +2985,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Edit/Esc/Tests/data/entities.dxf
+++ b/scripts/Edit/Esc/Tests/data/entities.dxf
@@ -2969,7 +2969,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Edit/Esc/Tests/required/EActionTest03_000.dxf
+++ b/scripts/Edit/Esc/Tests/required/EActionTest03_000.dxf
@@ -3865,7 +3865,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Information/InfoArcCircleArea/doc/ArcCircleArea.dxf
+++ b/scripts/Information/InfoArcCircleArea/doc/ArcCircleArea.dxf
@@ -1093,7 +1093,7 @@ ELECTRIC
  70
 0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
 65
  73

--- a/scripts/Information/InfoDistanceEE/Tests/required/InfoDistanceEETest00_000.dxf
+++ b/scripts/Information/InfoDistanceEE/Tests/required/InfoDistanceEETest00_000.dxf
@@ -2429,7 +2429,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Information/InfoDistanceEE/Tests/required/InfoDistanceEETest01_000.dxf
+++ b/scripts/Information/InfoDistanceEE/Tests/required/InfoDistanceEETest01_000.dxf
@@ -2429,7 +2429,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Information/InfoDistanceEE/Tests/required/InfoDistanceEETest02_000.dxf
+++ b/scripts/Information/InfoDistanceEE/Tests/required/InfoDistanceEETest02_000.dxf
@@ -2429,7 +2429,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Information/InfoDistanceEE/Tests/required/InfoDistanceEETest03_000.dxf
+++ b/scripts/Information/InfoDistanceEE/Tests/required/InfoDistanceEETest03_000.dxf
@@ -3755,7 +3755,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Information/InfoDistanceEE/Tests/required/InfoDistanceEETest04_000.dxf
+++ b/scripts/Information/InfoDistanceEE/Tests/required/InfoDistanceEETest04_000.dxf
@@ -3755,7 +3755,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Information/InfoDistanceEP/Tests/required/InfoDistanceEPTest00_000.dxf
+++ b/scripts/Information/InfoDistanceEP/Tests/required/InfoDistanceEPTest00_000.dxf
@@ -2429,7 +2429,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Information/InfoDistancePP/Tests/required/InfoDistancePPTest00_000.dxf
+++ b/scripts/Information/InfoDistancePP/Tests/required/InfoDistancePPTest00_000.dxf
@@ -2429,7 +2429,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/AutoTrim/Tests/data/line_xline_ray.dxf
+++ b/scripts/Modify/AutoTrim/Tests/data/line_xline_ray.dxf
@@ -3639,7 +3639,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/AutoTrim/Tests/data/polylines.dxf
+++ b/scripts/Modify/AutoTrim/Tests/data/polylines.dxf
@@ -1587,7 +1587,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/AutoTrim/Tests/data/splines.dxf
+++ b/scripts/Modify/AutoTrim/Tests/data/splines.dxf
@@ -3019,7 +3019,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest00_000.dxf
+++ b/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest01_000.dxf
+++ b/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest01_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest02_000.dxf
+++ b/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest02_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest03_000.dxf
+++ b/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest03_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest04_000.dxf
+++ b/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest04_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest05_000.dxf
+++ b/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest05_000.dxf
@@ -2269,7 +2269,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest06_000.dxf
+++ b/scripts/Modify/AutoTrim/Tests/required/AutoTrimTest06_000.dxf
@@ -2269,7 +2269,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Bevel/Tests/required/BevelTest00_000.dxf
+++ b/scripts/Modify/Bevel/Tests/required/BevelTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Bevel/Tests/required/BevelTest01_000.dxf
+++ b/scripts/Modify/Bevel/Tests/required/BevelTest01_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Bevel/Tests/required/BevelTest02_000.dxf
+++ b/scripts/Modify/Bevel/Tests/required/BevelTest02_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Bevel/Tests/required/BevelTest03_000.dxf
+++ b/scripts/Modify/Bevel/Tests/required/BevelTest03_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Bevel/Tests/required/BevelTest04_000.dxf
+++ b/scripts/Modify/Bevel/Tests/required/BevelTest04_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Bevel/Tests/required/BevelTest05_000.dxf
+++ b/scripts/Modify/Bevel/Tests/required/BevelTest05_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Bevel/Tests/required/BevelTest06_000.dxf
+++ b/scripts/Modify/Bevel/Tests/required/BevelTest06_000.dxf
@@ -2229,7 +2229,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Bevel/Tests/required/BevelTest07_000.dxf
+++ b/scripts/Modify/Bevel/Tests/required/BevelTest07_000.dxf
@@ -2647,7 +2647,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/data/line_xline_ray.dxf
+++ b/scripts/Modify/BreakOut/Tests/data/line_xline_ray.dxf
@@ -3639,7 +3639,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/data/line_xline_ray2.dxf
+++ b/scripts/Modify/BreakOut/Tests/data/line_xline_ray2.dxf
@@ -3639,7 +3639,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/data/polylines.dxf
+++ b/scripts/Modify/BreakOut/Tests/data/polylines.dxf
@@ -1587,7 +1587,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/data/splines.dxf
+++ b/scripts/Modify/BreakOut/Tests/data/splines.dxf
@@ -3019,7 +3019,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/required/BreakOutTest00_000.dxf
+++ b/scripts/Modify/BreakOut/Tests/required/BreakOutTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/required/BreakOutTest01_000.dxf
+++ b/scripts/Modify/BreakOut/Tests/required/BreakOutTest01_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/required/BreakOutTest02_000.dxf
+++ b/scripts/Modify/BreakOut/Tests/required/BreakOutTest02_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/required/BreakOutTest03_000.dxf
+++ b/scripts/Modify/BreakOut/Tests/required/BreakOutTest03_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/required/BreakOutTest04_000.dxf
+++ b/scripts/Modify/BreakOut/Tests/required/BreakOutTest04_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/required/BreakOutTest05_000.dxf
+++ b/scripts/Modify/BreakOut/Tests/required/BreakOutTest05_000.dxf
@@ -1717,7 +1717,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/required/BreakOutTest06_000.dxf
+++ b/scripts/Modify/BreakOut/Tests/required/BreakOutTest06_000.dxf
@@ -1717,7 +1717,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/required/BreakOutTest07_000.dxf
+++ b/scripts/Modify/BreakOut/Tests/required/BreakOutTest07_000.dxf
@@ -2269,7 +2269,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOut/Tests/required/BreakOutTest08_000.dxf
+++ b/scripts/Modify/BreakOut/Tests/required/BreakOutTest08_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/BreakOutGap/Tests/required/BreakOutGapTest01_000.dxf
+++ b/scripts/Modify/BreakOutGap/Tests/required/BreakOutGapTest01_000.dxf
@@ -1757,7 +1757,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Divide/Tests/data/polylines.dxf
+++ b/scripts/Modify/Divide/Tests/data/polylines.dxf
@@ -1587,7 +1587,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Divide/Tests/required/DivideTest01_000.dxf
+++ b/scripts/Modify/Divide/Tests/required/DivideTest01_000.dxf
@@ -3557,7 +3557,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Divide/Tests/required/DivideTest02_000.dxf
+++ b/scripts/Modify/Divide/Tests/required/DivideTest02_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Explode/Tests/data/splines.dxf
+++ b/scripts/Modify/Explode/Tests/data/splines.dxf
@@ -3811,7 +3811,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Explode/Tests/required/ExplodeTest01_000.dxf
+++ b/scripts/Modify/Explode/Tests/required/ExplodeTest01_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Explode/Tests/required/ExplodeTest02_000.dxf
+++ b/scripts/Modify/Explode/Tests/required/ExplodeTest02_000.dxf
@@ -2847,7 +2847,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Explode/Tests/required/ExplodeTest03_000.dxf
+++ b/scripts/Modify/Explode/Tests/required/ExplodeTest03_000.dxf
@@ -2243,7 +2243,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Lengthen/Tests/required/LengthenTest00_000.dxf
+++ b/scripts/Modify/Lengthen/Tests/required/LengthenTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Lengthen/Tests/required/LengthenTest01_000.dxf
+++ b/scripts/Modify/Lengthen/Tests/required/LengthenTest01_000.dxf
@@ -2505,7 +2505,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Lengthen/Tests/required/LengthenTest02_000.dxf
+++ b/scripts/Modify/Lengthen/Tests/required/LengthenTest02_000.dxf
@@ -3249,7 +3249,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Lengthen/Tests/required/LengthenTest03_000.dxf
+++ b/scripts/Modify/Lengthen/Tests/required/LengthenTest03_000.dxf
@@ -3769,7 +3769,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Mirror/Tests/required/MirrorTest00_000.dxf
+++ b/scripts/Modify/Mirror/Tests/required/MirrorTest00_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Mirror/Tests/required/MirrorTest01_000.dxf
+++ b/scripts/Modify/Mirror/Tests/required/MirrorTest01_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Offset/Tests/required/OffsetTest00_001.dxf
+++ b/scripts/Modify/Offset/Tests/required/OffsetTest00_001.dxf
@@ -3777,7 +3777,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Offset/Tests/required/OffsetTest01_000.dxf
+++ b/scripts/Modify/Offset/Tests/required/OffsetTest01_000.dxf
@@ -2997,7 +2997,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Offset/Tests/required/OffsetTest02_000.dxf
+++ b/scripts/Modify/Offset/Tests/required/OffsetTest02_000.dxf
@@ -1591,7 +1591,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Reverse/Tests/data/entities.dxf
+++ b/scripts/Modify/Reverse/Tests/data/entities.dxf
@@ -2985,7 +2985,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Reverse/Tests/required/ReverseTest00_000.dxf
+++ b/scripts/Modify/Reverse/Tests/required/ReverseTest00_000.dxf
@@ -3835,7 +3835,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Rotate/Tests/required/RotateTest00_000.dxf
+++ b/scripts/Modify/Rotate/Tests/required/RotateTest00_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Rotate2/Tests/required/Rotate2Test01_000.dxf
+++ b/scripts/Modify/Rotate2/Tests/required/Rotate2Test01_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Rotate2/Tests/required/Rotate2Test02_000.dxf
+++ b/scripts/Modify/Rotate2/Tests/required/Rotate2Test02_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Rotate2/Tests/required/Rotate2Test03_000.dxf
+++ b/scripts/Modify/Rotate2/Tests/required/Rotate2Test03_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Rotate2/Tests/required/Rotate2Test05_000.dxf
+++ b/scripts/Modify/Rotate2/Tests/required/Rotate2Test05_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Rotate2/Tests/required/Rotate2Test06_000.dxf
+++ b/scripts/Modify/Rotate2/Tests/required/Rotate2Test06_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Round/Tests/required/RoundTest00_000.dxf
+++ b/scripts/Modify/Round/Tests/required/RoundTest00_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Round/Tests/required/RoundTest01_000.dxf
+++ b/scripts/Modify/Round/Tests/required/RoundTest01_000.dxf
@@ -1711,7 +1711,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Scale/Tests/required/ScaleTest00_000.dxf
+++ b/scripts/Modify/Scale/Tests/required/ScaleTest00_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Scale/Tests/required/ScaleTest01_000.dxf
+++ b/scripts/Modify/Scale/Tests/required/ScaleTest01_000.dxf
@@ -3069,7 +3069,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Scale/Tests/required/ScaleTest02_000.dxf
+++ b/scripts/Modify/Scale/Tests/required/ScaleTest02_000.dxf
@@ -3069,7 +3069,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Scale/Tests/required/ScaleTest03_000.dxf
+++ b/scripts/Modify/Scale/Tests/required/ScaleTest03_000.dxf
@@ -3069,7 +3069,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Scale/Tests/required/ScaleTest04_000.dxf
+++ b/scripts/Modify/Scale/Tests/required/ScaleTest04_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Scale/Tests/required/ScaleTest05_000.dxf
+++ b/scripts/Modify/Scale/Tests/required/ScaleTest05_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Scale/Tests/required/ScaleTest06_000.dxf
+++ b/scripts/Modify/Scale/Tests/required/ScaleTest06_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Scale/Tests/required/ScaleTest07_000.dxf
+++ b/scripts/Modify/Scale/Tests/required/ScaleTest07_000.dxf
@@ -3069,7 +3069,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Stretch/Tests/data/entities2.dxf
+++ b/scripts/Modify/Stretch/Tests/data/entities2.dxf
@@ -2221,7 +2221,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Stretch/Tests/required/StretchTest00_000.dxf
+++ b/scripts/Modify/Stretch/Tests/required/StretchTest00_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Stretch/Tests/required/StretchTest06_000.dxf
+++ b/scripts/Modify/Stretch/Tests/required/StretchTest06_000.dxf
@@ -3443,7 +3443,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Translate/Tests/required/TranslateTest00_000.dxf
+++ b/scripts/Modify/Translate/Tests/required/TranslateTest00_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Translate/Tests/required/TranslateTest01_000.dxf
+++ b/scripts/Modify/Translate/Tests/required/TranslateTest01_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Translate/Tests/required/TranslateTest02_000.dxf
+++ b/scripts/Modify/Translate/Tests/required/TranslateTest02_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/TranslateRotate/Tests/required/TranslateRotateTest00_000.dxf
+++ b/scripts/Modify/TranslateRotate/Tests/required/TranslateRotateTest00_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/TranslateRotate/Tests/required/TranslateRotateTest01_000.dxf
+++ b/scripts/Modify/TranslateRotate/Tests/required/TranslateRotateTest01_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/TranslateRotate/Tests/required/TranslateRotateTest02_000.dxf
+++ b/scripts/Modify/TranslateRotate/Tests/required/TranslateRotateTest02_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/data/line_ray_xline.dxf
+++ b/scripts/Modify/Trim/Tests/data/line_ray_xline.dxf
@@ -3373,7 +3373,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/data/line_spline.dxf
+++ b/scripts/Modify/Trim/Tests/data/line_spline.dxf
@@ -3517,7 +3517,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/data/tangent.dxf
+++ b/scripts/Modify/Trim/Tests/data/tangent.dxf
@@ -2419,7 +2419,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest00_000.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest00_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest01_000.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest01_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest02_000.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest02_000.dxf
@@ -3651,7 +3651,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest03_000.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest03_000.dxf
@@ -3679,7 +3679,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest04_000.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest04_000.dxf
@@ -3679,7 +3679,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest05_000.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest05_000.dxf
@@ -3679,7 +3679,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest06_000.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest06_000.dxf
@@ -3679,7 +3679,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest07_000.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest07_000.dxf
@@ -3679,7 +3679,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest08_000.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest08_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest09_000.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest09_000.dxf
@@ -3339,7 +3339,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest10_000.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest10_000.dxf
@@ -3069,7 +3069,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest10_001.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest10_001.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/Trim/Tests/required/TrimTest11_000.dxf
+++ b/scripts/Modify/Trim/Tests/required/TrimTest11_000.dxf
@@ -2945,7 +2945,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/TrimBoth/Tests/data/closed_polylines.dxf
+++ b/scripts/Modify/TrimBoth/Tests/data/closed_polylines.dxf
@@ -3683,7 +3683,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/TrimBoth/Tests/data/line_ray_xline.dxf
+++ b/scripts/Modify/TrimBoth/Tests/data/line_ray_xline.dxf
@@ -3373,7 +3373,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/TrimBoth/Tests/data/open_polylines.dxf
+++ b/scripts/Modify/TrimBoth/Tests/data/open_polylines.dxf
@@ -3683,7 +3683,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/TrimBoth/Tests/data/same_polylines.dxf
+++ b/scripts/Modify/TrimBoth/Tests/data/same_polylines.dxf
@@ -3683,7 +3683,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/TrimBoth/Tests/required/TrimBothTest00_000.dxf
+++ b/scripts/Modify/TrimBoth/Tests/required/TrimBothTest00_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/TrimBoth/Tests/required/TrimBothTest01_000.dxf
+++ b/scripts/Modify/TrimBoth/Tests/required/TrimBothTest01_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/TrimBoth/Tests/required/TrimBothTest02_000.dxf
+++ b/scripts/Modify/TrimBoth/Tests/required/TrimBothTest02_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/TrimBoth/Tests/required/TrimBothTest03_000.dxf
+++ b/scripts/Modify/TrimBoth/Tests/required/TrimBothTest03_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Modify/TrimBoth/Tests/required/TrimBothTest04_000.dxf
+++ b/scripts/Modify/TrimBoth/Tests/required/TrimBothTest04_000.dxf
@@ -3771,7 +3771,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Snap/SnapIntersection/Tests/data/arc.dxf
+++ b/scripts/Snap/SnapIntersection/Tests/data/arc.dxf
@@ -1837,7 +1837,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Snap/SnapIntersection/Tests/data/ellipse.dxf
+++ b/scripts/Snap/SnapIntersection/Tests/data/ellipse.dxf
@@ -2229,7 +2229,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Snap/SnapIntersection/Tests/data/line.dxf
+++ b/scripts/Snap/SnapIntersection/Tests/data/line.dxf
@@ -3159,7 +3159,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Snap/SnapIntersection/Tests/data/polyline.dxf
+++ b/scripts/Snap/SnapIntersection/Tests/data/polyline.dxf
@@ -2289,7 +2289,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Snap/SnapIntersection/Tests/data/polyline_xline.dxf
+++ b/scripts/Snap/SnapIntersection/Tests/data/polyline_xline.dxf
@@ -1717,7 +1717,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Snap/SnapIntersection/Tests/data/spline.dxf
+++ b/scripts/Snap/SnapIntersection/Tests/data/spline.dxf
@@ -2289,7 +2289,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Snap/SnapIntersection/Tests/required/SnapIntersectionTest00_000.dxf
+++ b/scripts/Snap/SnapIntersection/Tests/required/SnapIntersectionTest00_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Snap/SnapIntersection/Tests/required/SnapIntersectionTest01_000.dxf
+++ b/scripts/Snap/SnapIntersection/Tests/required/SnapIntersectionTest01_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Snap/SnapIntersection/Tests/required/SnapIntersectionTest02_000.dxf
+++ b/scripts/Snap/SnapIntersection/Tests/required/SnapIntersectionTest02_000.dxf
@@ -1535,7 +1535,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Snap/SnapIntersection/Tests/required/SnapIntersectionTest03_000.dxf
+++ b/scripts/Snap/SnapIntersection/Tests/required/SnapIntersectionTest03_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Snap/SnapIntersection/Tests/required/SnapIntersectionTest04_000.dxf
+++ b/scripts/Snap/SnapIntersection/Tests/required/SnapIntersectionTest04_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/scripts/Snap/SnapIntersection/Tests/required/SnapIntersectionTest05_000.dxf
+++ b/scripts/Snap/SnapIntersection/Tests/required/SnapIntersectionTest05_000.dxf
@@ -3781,7 +3781,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/support/data/examples/rendering.dxf
+++ b/support/data/examples/rendering.dxf
@@ -2409,7 +2409,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73

--- a/support/data/tests/hatch/hatch001.dxf
+++ b/support/data/tests/hatch/hatch001.dxf
@@ -2337,7 +2337,7 @@ ELECTRIC
  70
      0
   3
-Electical ---- E ---- E ---- E ----
+Electrical ---- E ---- E ---- E ----
  72
     65
  73


### PR DESCRIPTION
Found via `codespell v2.1.dev0`