### PR TITLE
Fix misc. typos

### DIFF
--- a/src/core/RTextBasedEntity.cpp
+++ b/src/core/RTextBasedEntity.cpp
@@ -201,7 +201,7 @@ void RTextBasedEntity::exportEntity(RExporter& e, bool preview, bool forceSelect
     Q_UNUSED(preview)
 
     // TODO: use transforms:
-    // use reference, so we don't loose aspects of attribute definition and other derrived entity types:
+    // use reference, so we don't loose aspects of attribute definition and other derived entity types:
     const RTextBasedData& data = getData();
 //    data.move(-getAlignmentPoint());
 //    data.rotate(-getAngle(), RVector(0,0));

--- a/src/core/RTextRenderer.cpp
+++ b/src/core/RTextRenderer.cpp
@@ -786,7 +786,7 @@ void RTextRenderer::render() {
 //                        qDebug() << "textLayouts:" << textLayouts.length();
 
 //                        // potential future line break:
-//                        // remeber state at this point:
+//                        // remember state at this point:
 //                        breakPointFormats = formats;
 //                        breakPointCurrentFormat = currentFormat;
 //                        // start new line _after_ white space and skip whitespace in case of break:

--- a/src/gui/RGraphicsSceneQt.cpp
+++ b/src/gui/RGraphicsSceneQt.cpp
@@ -295,7 +295,7 @@ void RGraphicsSceneQt::transformAndApplyPatternPath(RPainterPath& path) const {
             for (int i=0; i<pathShapes.length(); i++) {
                 length += pathShapes[i]->getLength();
             }
-            //qDebug() << "pattern offet:" << lp.getPatternOffset(length);
+            //qDebug() << "pattern offset:" << lp.getPatternOffset(length);
             RShapesExporter(ppe, pathShapes, lp.getPatternOffset(length));
             //lp.getPatternOffset(length));
             RPainterPath p = ppe.getPainterPath();
@@ -328,7 +328,7 @@ void RGraphicsSceneQt::transformAndApplyPatternPath(RPainterPath& path) const {
                     //length = pathShapes[i]->getLength();
                 }
 
-                //qDebug() << "pattern offet:" << lp.getPatternOffset(length);
+                //qDebug() << "pattern offset:" << lp.getPatternOffset(length);
                 RShapesExporter(ppe, shapes, offset);
                 //lp.getPatternOffset(length));
                 RPainterPath p = ppe.getPainterPath();

--- a/src/gui/RMainWindowQt.cpp
+++ b/src/gui/RMainWindowQt.cpp
@@ -636,7 +636,7 @@ bool RMainWindowQt::event(QEvent* e) {
         return false;
     }
 
-    // TODO: never triggered on macOS when draging title bar icon
+    // TODO: never triggered on macOS when dragging title bar icon
 //    QIconDragEvent* ide = dynamic_cast<QIconDragEvent*>(e);
 //    if (ide!=NULL) {
 //        qDebug() << "QIconDragEvent";


### PR DESCRIPTION
Found via `codespell -q 3 -L adresse,afe,atleast,ba,dum,lightyear,objekt,referenz,serie,te,ue -S *.html,*.ts,./src/3rdparty`