### PR TITLE
Add bearing entry as alternative angle entry (FS2037)

### DIFF
--- a/src/core/math/RMath.cpp
+++ b/src/core/math/RMath.cpp
@@ -328,6 +328,43 @@ double RMath::eval(const QString& expression, bool* ok) {
         } while(idx!=-1);
     }
 
+    //qDebug() << "RMath::eval: expression 004 is: " << expr;
+
+    // convert explicitly indicated bearing angles (e.g. "90b30'5\"") to degrees:
+    {
+        QRegExp re(
+            "(?:[^a-zA-Z0-9]|^)"                                // not preceded by letter or number (could be part of a function)
+            "("
+              "(?:((?:\\.\\d+)|(?:\\d+\\.\\d*)|(?:\\d+))b)"  // degrees
+              "(?:((?:\\.\\d+)|(?:\\d+\\.\\d*)|(?:\\d+))')?"    // minutes
+              "(?:((?:\\.\\d+)|(?:\\d+\\.\\d*)|(?:\\d+))\")?"   // seconds
+            ")"
+            "(?:[^\\d]|$)",             // followed by not a number or end
+            Qt::CaseInsensitive, QRegExp::RegExp2);
+        do {
+            idx = re.indexIn(expr);
+            if (idx==-1) {
+                break;
+            }
+
+            double degrees = 0.0;
+            double minutes = 0.0;
+            double seconds = 0.0;
+            degrees = re.cap(2).toDouble(ok);
+            minutes = re.cap(3).toDouble(ok);
+            seconds = re.cap(4).toDouble(ok);
+
+            double angle = degrees + minutes/60.0 + seconds/3600.0;
+            angle = 90.0 - angle;
+            angle = fmod(angle,360.0);
+
+            expr.replace(
+                re.cap(1),
+                QString("%1").arg(angle, 0, 'g', 16)
+            );
+        } while(idx!=-1);
+    }
+
     // convert fraction notation to formula:
     // e.g. 7 3/32 to (7+3/32)
     {


### PR DESCRIPTION
Possible solution for FS2037. 
The changes allow entry of bearings into the command line where 0 degree is north, and clockwise angles.  

When adding a line angle you can enter the bearing of the line in reference to zero degrees north, and clock wise.  For example 12b32'43".

