### PR TITLE
Add win32 option for qcadcmd.com

### DIFF
--- a/src/console/console.pro
+++ b/src/console/console.pro
@@ -3,4 +3,5 @@ include( ../run/run.pri )
 CONFIG += console
 TARGET = qcadcmd.com
 
-QMAKE_POST_LINK = mv "$${DESTDIR}/qcadcmd.com.exe" "$${DESTDIR}/qcadcmd.com"
+win32:QMAKE_POST_LINK = rename "$$replace(DESTDIR, /, \\)\\qcadcmd.com.exe" "qcadcmd.com"
+unix:QMAKE_POST_LINK = mv "$${DESTDIR}/qcadcmd.com.exe" "$${DESTDIR}/qcadcmd.com"


### PR DESCRIPTION
Add win32 option.
Convert mv command to rename.
Convert UNIX path to Windows path.