### PR TITLE
Update ECMAScript link and description

### DIFF
--- a/qcad.dox
+++ b/qcad.dox
@@ -71,7 +71,7 @@ They may also be used by other applications.
 - \subpage ScriptOverviews
 - \subpage ScriptTutorials
 - \ref ecma_scripts "ECMAScript classes and libraries"
-- <a href="http://www.ecmascript.org" target="_blank">ECMAScript Language Standard</a>
+- <a href="https://doc.qt.io/archives/qt-5.13/qtscript-index.html" target="_blank">QtScript reference with further ECMAScript pointers</a>
 
 <p>&nbsp;</p>
 


### PR DESCRIPTION
Since the application uses Qt and QtScript implementation of the ECMAScript standard, the link should point to the documentation of the current used Qt version. Also, the previous link to ecmascript.org was dead.