### PR TITLE
Fix finding of patterns and linetypes from measurement system.

### DIFF
--- a/scripts/Draw/Hatch/HatchDialog.js
+++ b/scripts/Draw/Hatch/HatchDialog.js
@@ -73,7 +73,9 @@ HatchDialog.prototype.show =  function(hatchDataIn) {
     imageView.setMargin(10);
 
     var patternNames;
-    if (RUnit.isMetric(EAction.getDocument().getUnit())) {
+    // Use the document measurement setting (as indicated by the UI) instead
+    // of the document unit.
+    if (EAction.getDocument().isMetric()) {
         patternNames = RPatternListMetric.getNames();
     }
     else {

--- a/scripts/Widgets/PropertyEditor/PropertyEditor.js
+++ b/scripts/Widgets/PropertyEditor/PropertyEditor.js
@@ -949,7 +949,9 @@ PropertyEditorImpl.prototype.initControls = function(propertyTypeId, onlyChanges
     // Hatch pattern: combo box with hatch names:
     else if (propertyTypeId.getId()===RHatchEntity.PropertyPatternName.getId()) {
         var patternNames = undefined;
-        if (RUnit.isMetric(EAction.getDocument().getUnit())) {
+        // Use the document measurement setting (as indicated by the UI) instead
+        // of the document unit.
+        if (EAction.getDocument().isMetric()) {
             patternNames = RPatternListMetric.getNames();
         }
         else {

--- a/src/3rdparty/opennurbs/opennurbs/CMakeLists.txt
+++ b/src/3rdparty/opennurbs/opennurbs/CMakeLists.txt
@@ -5,7 +5,8 @@ IF(WIN32)
 	#SET(RC ../opennurbs.rc)
 ENDIF()
 
-add_library(opennurbs SHARED
+# Make this library static to agree with the qmake .pro file
+add_library(opennurbs STATIC
     ../opennurbs.h
     ../opennurbs_3dm.h
     ../opennurbs_3dm_attributes.cpp ../opennurbs_3dm_attributes.h

--- a/src/3rdparty/opennurbs/zlib/CMakeLists.txt
+++ b/src/3rdparty/opennurbs/zlib/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(zlib VERSION 1.0 LANGUAGES C)
 
-add_library(zlib SHARED
+# Make this library static to agree with the qmake .pro file
+add_library(zlib STATIC
     adler32.c
     compress.c
     crc32.c crc32.h

--- a/src/core/RDocument.cpp
+++ b/src/core/RDocument.cpp
@@ -204,7 +204,6 @@ void RDocument::init(bool beforeLoad) {
         // default variables:
         docVars->setUnit(defaultUnit);
         docVars->setMeasurement(measurement);
-        initLinetypes(&transaction);
         docVars->setLinetypeScale(RSettings::getDoubleValue("LinetypeSettings/Scale", 1.0));
 
         // point display:
@@ -363,7 +362,10 @@ void RDocument::init(bool beforeLoad) {
     }
 
     transaction.addObject(docVars);
-
+    // The linetypes cannot be initialized until the docVars are added to
+    // the transaction.
+    initLinetypes(&transaction);
+    
     QSharedPointer<RDimStyle> dimStyle = QSharedPointer<RDimStyle>(new RDimStyle(this));
     transaction.addObject(dimStyle);
 
@@ -394,7 +396,9 @@ QList<QSharedPointer<RObject> > RDocument::getDefaultLinetypes() {
 
     // read patterns from file system and add to doc:
     QStringList patternList;
-    if (RUnit::isMetric(getUnit())) {
+    // Use the measurement setting instead of the unit as defined
+    // in the user interface.
+    if (isMetric()) {
         patternList = RLinetypeListMetric::getNames();
     }
     else {
@@ -404,7 +408,9 @@ QList<QSharedPointer<RObject> > RDocument::getDefaultLinetypes() {
         QString name = patternList[i];
 
         RLinetypePattern* pattern = NULL;
-        if (RUnit::isMetric(getUnit())) {
+        // Use the measurement setting instead of the unit as defined
+        // in the user interface.
+        if (isMetric()) {
             pattern = RLinetypeListMetric::get(name);
         }
         else {

--- a/src/core/RPluginLoader.cpp
+++ b/src/core/RPluginLoader.cpp
@@ -69,8 +69,10 @@ QStringList RPluginLoader::getPluginFiles() {
         else {
 #ifdef QT_DEBUG
             // release plugin but built in debug mode: skip:
-            qDebug() << "Ignoring release plugin built in debug mode: " << fileName;
-            continue;
+            // CMAKE and QMAKE build rules removed building debug version
+            // with _debug suffix.            
+            // qDebug() << "Ignoring release plugin built in debug mode: " << fileName;
+            // continue;
 #endif
         }
 


### PR DESCRIPTION
The current code depends on the document unit instead of the measurement system - although the user interface says otherwise. In addition, the linetypes are initialized before the document has its variables defined. Fixed the CMakeLists.txt to be consisted with qmake. Fixed the plugin loaded to not expect _debug in dll plugin names - to be consistent with changes to both qmake and cmake.