### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/src/3rdparty/opennurbs/zlib/crc32.c
+++ b/src/3rdparty/opennurbs/zlib/crc32.c
@@ -293,7 +293,7 @@ local unsigned long crc32_little(crc, buf, len)
 }
 
 /* ========================================================================= */
-#define DOBIG4 c ^= *++buf4; \
+#define DOBIG4 c ^= *buf4++; \
         c = crc_table[4][c & 0xff] ^ crc_table[5][(c >> 8) & 0xff] ^ \
             crc_table[6][(c >> 16) & 0xff] ^ crc_table[7][c >> 24]
 #define DOBIG32 DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4
@@ -315,7 +315,6 @@ local unsigned long crc32_big(crc, buf, len)
     }
 
     buf4 = (const u4 FAR *)(const void FAR *)buf;
-    buf4--;
     while (len >= 32) {
         DOBIG32;
         len -= 32;
@@ -324,7 +323,6 @@ local unsigned long crc32_big(crc, buf, len)
         DOBIG4;
         len -= 4;
     }
-    buf4++;
     buf = (const unsigned char FAR *)buf4;
 
     if (len) do {


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a clone function crc32_big() in `src/3rdparty/opennurbs/zlib/crc32.c` sourced from [madler/zlib](https://github.com/madler/zlib). This issue, originally reported in [CVE-2016-9843](https://nvd.nist.gov/vuln/detail/CVE-2016-9843), was resolved in the repository via this commit https://github.com/madler/zlib/commit/d1d577490c15a0c6862473d7576352a9f18ef811.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!