### PR TITLE
Fix duplicate Ukrainian translation for Dark Cyan color

### DIFF
--- a/ts/qcadcore_uk.ts
+++ b/ts/qcadcore_uk.ts
@@ -174,7 +174,7 @@
     <message>
         <location line="+1"/>
         <source>Dark Cyan</source>
-        <translation>Темно-синій</translation>
+        <translation>Темно-бірюзовий</translation>
     </message>
     <message>
         <location line="+1"/>


### PR DESCRIPTION
This pull request fixes an incorrect Ukrainian translation where both “Dark Blue” and “Dark Cyan” were translated as “Темно-синій”.
The translation for “Dark Cyan” has been corrected to “Темно-бірюзовий” to avoid ambiguity and better reflect the actual color.