### PR TITLE
Improve Ukrainian translations for rows and columns parameters

### DIFF
--- a/ts/qcadcore_uk.ts
+++ b/ts/qcadcore_uk.ts
@@ -370,7 +370,7 @@
     <message>
         <location line="+1"/>
         <source>Columns</source>
-        <translation>Колонки</translation>
+        <translation>Стовпчики</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -385,7 +385,7 @@
     <message>
         <location line="+1"/>
         <source>Row Spacing</source>
-        <translation>Міжряддя</translation>
+        <translation>Відстань між рядами</translation>
     </message>
     <message>
         <location line="+3"/>


### PR DESCRIPTION
This pull request improves the Ukrainian user interface translation related to row and column parameters.

In a CAD and engineering context, the terms Columns and Rows refer to structural or array elements rather than typographic concepts. Therefore, “Columns” is translated as “Стовпчики” instead of “Колонки”, which is ambiguous in technical Ukrainian.

Similarly, “Row Spacing” was previously translated as “Міжряддя”, a term primarily associated with typography. It has been replaced with “Відстань між рядами” to ensure terminological clarity and consistency with the existing parameter “Відстань між стовпчиками”.

These changes aim to improve precision and consistency of Ukrainian terminology in the QCAD interface.