### PR TITLE
Improve Ukrainian translation for Parent Id

### DIFF
--- a/ts/qcadcore_uk.ts
+++ b/ts/qcadcore_uk.ts
@@ -370,7 +370,7 @@
     <message>
         <location line="+1"/>
         <source>Columns</source>
-        <translation>Стовпчики</translation>
+        <translation>Колонки</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -385,7 +385,7 @@
     <message>
         <location line="+1"/>
         <source>Row Spacing</source>
-        <translation>Відстань між рядами</translation>
+        <translation>Міжряддя</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -564,7 +564,7 @@
     <message>
         <location line="+2"/>
         <source>Parent Id</source>
-        <translation>Ідентифікатор батька</translation>
+        <translation>Ідентифікатор батьківського елемента</translation>
     </message>
     <message>
         <location line="+2"/>


### PR DESCRIPTION
This pull request improves the Ukrainian translation of the term “Parent Id”.

The previous translation used a literal rendering that may sound anthropomorphic in Ukrainian and is not optimal for technical user interfaces. It has been replaced with “Ідентифікатор батьківського елемента”, which more accurately reflects a hierarchical relationship between elements or entities in a CAD system.