### PR TITLE
Improve Ukrainian translations for left and right directions

### DIFF
--- a/ts/qcadcore_uk.ts
+++ b/ts/qcadcore_uk.ts
@@ -564,7 +564,7 @@
     <message>
         <location line="+2"/>
         <source>Parent Id</source>
-        <translation>Ідентифікатор батьківського елемента</translation>
+        <translation>Ідентифікатор батька</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -578,7 +578,7 @@
         <location line="-3"/>
         <location filename="../src/core/RLayout.cpp" line="+3"/>
         <source>Left</source>
-        <translation>Зліва</translation>
+        <translation>Ліворуч</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -590,7 +590,7 @@
         <location line="+1"/>
         <location filename="../src/core/RLayout.cpp" line="+1"/>
         <source>Right</source>
-        <translation>Справа</translation>
+        <translation>Праворуч</translation>
     </message>
     <message>
         <location line="+1"/>


### PR DESCRIPTION
This pull request refines the Ukrainian translations of the directional terms “Left” and “Right” used in layout and alignment contexts.

The previous translations “Зліва” and “Справа” are more colloquial and may be ambiguous in technical interfaces. They have been replaced with the normative directional forms “Ліворуч” and “Праворуч”, which are more appropriate for precise UI labeling.

The change improves linguistic accuracy and ensures consistent terminology in the QCAD user interface.