### PR TITLE
Fix malformed translation tag in scripts_uk.ts (line 5362)

### DIFF
--- a/ts/scripts_uk.ts
+++ b/ts/scripts_uk.ts
@@ -5359,7 +5359,7 @@ is already in the list.</source>
     <message>
         <location line="+5"/>
         <source>SinusoidWave</source>
-        <translation>SinusoidWave/translation>
+        <translation>SinusoidWave</translation>
     </message>
     <message>
         <location line="+5"/>


### PR DESCRIPTION
This commit fixes a syntax error in scripts_uk.ts at line 5362, where the opening angle bracket of the <translation> tag was missing. The malformed entry has been corrected to restore valid TS/XML structure and ensure proper loading of the Ukrainian translation.