### PR TITLE
Harmonize Ukrainian titles of top-level menu items

### DIFF
--- a/ts/scripts_uk.ts
+++ b/ts/scripts_uk.ts
@@ -3304,7 +3304,7 @@ is already in the list.</source>
     <message>
         <location line="+4"/>
         <source>&amp;Draw</source>
-        <translation>Креслення</translation>
+        <translation>Побудова</translation>
     </message>
     <message>
         <location line="+15"/>
@@ -4396,7 +4396,7 @@ is already in the list.</source>
     <message>
         <location line="+26"/>
         <source>&amp;Edit</source>
-        <translation>Редагувати</translation>
+        <translation>Редагування</translation>
     </message>
 </context>
 <context>
@@ -9141,7 +9141,7 @@ is already in the list.</source>
     <message>
         <location line="+26"/>
         <source>&amp;Modify</source>
-        <translation>Змінити</translation>
+        <translation>Модифікація</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
This commit unifies the Ukrainian translations of the top-level (cascade) menu titles. The changes resolve inconsistencies in grammatical form and naming conventions across the main menu bar, ensuring stylistic and terminological coherence. No individual menu items were modified at this stage; the commit is intentionally limited to menu headers to keep the changes logically isolated and easy to review.