### PR TITLE
Print: re-apply drawing paper size after native print dialog

### DIFF
--- a/scripts/File/Print/Print.js
+++ b/scripts/File/Print/Print.js
@@ -116,18 +116,7 @@ Print.prototype.createPrinter = function(pdfFile, printerName, pdfVersion) {
         }
     }
 
-    // always use custom page size to work around Qt page size limitations:
-    var paperSizeMM = Print.getPaperSizeMM(this.document);
-    if (RSettings.getQtVersion() >= 0x060000) {
-        printer.setPageSize(new QPageSize(paperSizeMM, QPageSize.Millimeter));
-        printer.setFullPage(true);
-        printer.setPageOrientation(Print.getPageOrientationEnum(this.document));
-    }
-    else {
-        printer.setPaperSize(paperSizeMM, QPrinter.Millimeter);
-        printer.setFullPage(true);
-        printer.setOrientation(Print.getPageOrientationEnum(this.document));
-    }
+    Print.applyPageSize(printer, this.document);
 
     var colorMode = Print.getColorMode(this.document);
     if (colorMode == RGraphicsView.FullColor) {
@@ -188,9 +177,101 @@ Print.prototype.createPrinter = function(pdfFile, printerName, pdfVersion) {
             destr(printer);
             return undefined;
         }
+
+        // the native print dialog (Windows, macOS) hands the printer back to us
+        // with the device mode it received from the printer driver. Some drivers
+        // discard the page size we've set above and report their own default
+        // instead (e.g. A4 for a drawing set up for A3). Printing would then be
+        // clipped to that smaller page while print preview and PDF export remain
+        // correct. Re-apply the page size of the drawing in that case:
+        if (RSettings.getBoolValue("Print/EnforcePageSize", true)===true) {
+            Print.enforcePageSize(printer, this.document);
+        }
     }
 
     return printer;
+};
+
+/**
+ * Applies the paper size and orientation of the given document to the given printer.
+ *
+ * The paper size is always set as custom page size to work around Qt page size
+ * limitations.
+ */
+Print.applyPageSize = function(printer, document) {
+    var paperSizeMM = Print.getPaperSizeMM(document);
+    if (RSettings.getQtVersion() >= 0x060000) {
+        printer.setPageSize(new QPageSize(paperSizeMM, QPageSize.Millimeter));
+        printer.setFullPage(true);
+        printer.setPageOrientation(Print.getPageOrientationEnum(document));
+    }
+    else {
+        printer.setPaperSize(paperSizeMM, QPrinter.Millimeter);
+        printer.setFullPage(true);
+        printer.setOrientation(Print.getPageOrientationEnum(document));
+    }
+};
+
+/**
+ * Makes sure the given printer uses the paper size of the given document.
+ *
+ * Must be called before painting starts (QPainter.begin), since Qt ignores
+ * page size changes while the printer is active.
+ */
+Print.enforcePageSize = function(printer, document) {
+    var wantedSizeMM = Print.getOrientedPaperSizeMM(document);
+    var printerSizeMM = Print.getPrinterPaperSizeMM(printer);
+    if (Print.isSamePaperSize(wantedSizeMM, printerSizeMM)) {
+        return true;
+    }
+
+    qWarning(sprintf("Print: printer reports paper size %.1fx%.1fmm after print dialog, " +
+                     "drawing is set up for %.1fx%.1fmm. Re-applying paper size of drawing.",
+                     printerSizeMM.width(), printerSizeMM.height(),
+                     wantedSizeMM.width(), wantedSizeMM.height()));
+
+    Print.applyPageSize(printer, document);
+
+    printerSizeMM = Print.getPrinterPaperSizeMM(printer);
+    if (!Print.isSamePaperSize(wantedSizeMM, printerSizeMM)) {
+        qWarning(sprintf("Print: printer driver does not accept paper size %.1fx%.1fmm " +
+                         "(reports %.1fx%.1fmm). Printout may be clipped.",
+                         wantedSizeMM.width(), wantedSizeMM.height(),
+                         printerSizeMM.width(), printerSizeMM.height()));
+        return false;
+    }
+
+    return true;
+};
+
+/**
+ * \return True if the two given paper sizes (QSizeF in mm) are the same
+ * within a tolerance of 1mm.
+ */
+Print.isSamePaperSize = function(sizeMM1, sizeMM2) {
+    return Math.abs(sizeMM1.width() - sizeMM2.width()) < 1.0 &&
+           Math.abs(sizeMM1.height() - sizeMM2.height()) < 1.0;
+};
+
+/**
+ * \return Paper size of the given printer in mm as QSizeF, taking the page
+ * orientation into account (i.e. width > height for landscape).
+ */
+Print.getPrinterPaperSizeMM = function(printer) {
+    var paperRect = printer.paperRect(QPrinter.Millimeter);
+    return new QSizeF(paperRect.width(), paperRect.height());
+};
+
+/**
+ * \return Paper size of the given document in mm as QSizeF, taking the page
+ * orientation into account (i.e. width > height for landscape).
+ */
+Print.getOrientedPaperSizeMM = function(document) {
+    var paperSizeMM = Print.getPaperSizeMM(document);
+    if (Print.getPageOrientationEnum(document)===RS.Landscape) {
+        return new QSizeF(paperSizeMM.height(), paperSizeMM.width());
+    }
+    return paperSizeMM;
 };
 
 /**


### PR DESCRIPTION
## Problem

Customer report (QCAD/CAM 3.32.9, Windows 10, Brother MFC-J6540DW with the official Brother driver): printing directly from QCAD onto A3 only fills an A4-sized area, although the drawing's page settings say A3.

Notable from the report:

- QCAD's **print preview is correct** (A3).
- **PDF export prints perfectly** on A3 via the same printer.
- Excel and BricsCAD print A3 correctly on the same printer/driver.
- Only direct printing from QCAD is affected.

## Analysis

`Print.createPrinter()` set the drawing's paper size on the `QPrinter` **once**, *before* opening `QPrintDialog`, and never verified it afterwards.

On Windows the print dialog is the native `PrintDlgEx`, which round-trips a `DEVMODE` through the printer driver. Drivers are free to hand back a `DEVMODE` describing their own default paper (A4 here) instead of the one Qt seeded it with; Qt then adopts that page layout for the `QPrinter`.

`Print.printCurrentBlock()` doesn't notice: `printerFactor` is a mm→device-pixel *density*, which is identical for A3 and A4, so the drawing is still rendered at the correct physical scale — but onto an A4 paint device, so everything outside A4 is clipped. That matches the reported symptom exactly, and explains why preview (no printer) and PDF export (no native dialog) are unaffected. Excel/BricsCAD differ in that they take the page size *from* the driver rather than pushing their own.

## Change

- Factor the page size / orientation setup out of `Print.createPrinter()` into `Print.applyPageSize(printer, document)` (no behaviour change; both the Qt 5 and Qt 6 branches move as-is).
- After the print dialog is accepted, `Print.enforcePageSize()` compares the paper size the printer reports (`paperRect()`, orientation-aware, 1 mm tolerance) against the drawing's paper size. On a mismatch it re-applies the drawing's paper size — legal at that point, since `QPainter::begin()` hasn't run yet and Qt only ignores page size changes while the printer is active.
- Both the mismatch and a driver that still refuses the size are logged via `qWarning`, so this case is diagnosable from the customer's log instead of needing another round trip.
- Gated by `Print/EnforcePageSize` (default `true`) as an escape hatch.

Re-applying does not take anything away from the user: the drawing transform in `printCurrentBlock()` is derived from the document's paper size regardless, so a paper size chosen in the native dialog was never actually honoured — it only ever produced a clipped or mispositioned print.

## Status

Not yet confirmed on the affected hardware — the failure is driver-specific and can't be reproduced here. The added warnings make it verifiable: if the customer's log shows "printer reports paper size ... after print dialog", the diagnosis is confirmed; if it then also shows "printer driver does not accept paper size", the driver rejects A3 outright and the problem is below Qt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)