### PR TITLE
RGraphicsSceneQt: one map lookup instead of two

### DIFF
--- a/src/gui/RGraphicsSceneQt.cpp
+++ b/src/gui/RGraphicsSceneQt.cpp
@@ -952,8 +952,9 @@ void RGraphicsSceneQt::deleteDrawables() {
 }
 
 QList<RGraphicsSceneDrawable> RGraphicsSceneQt::getDrawablesList(REntity::Id entityId) {
-    if (drawables.contains(entityId)) {
-        return drawables[entityId];
+    QMap<RObject::Id, QList<RGraphicsSceneDrawable> >::const_iterator it = drawables.constFind(entityId);
+    if (it!=drawables.constEnd()) {
+        return it.value();
     }
     return QList<RGraphicsSceneDrawable>();
 }
@@ -963,9 +964,11 @@ QList<RGraphicsSceneDrawable> RGraphicsSceneQt::getDrawablesList(REntity::Id ent
  * given ID.
  */
 QList<RGraphicsSceneDrawable>* RGraphicsSceneQt::getDrawables(REntity::Id entityId) {
-    // TODO: check should not be necessary:
-    if (drawables.contains(entityId)) {
-        return &drawables[entityId];
+    // one lookup instead of two: this is called for every entity of every
+    // frame, contains() followed by operator[] walks the map twice:
+    QMap<RObject::Id, QList<RGraphicsSceneDrawable> >::iterator it = drawables.find(entityId);
+    if (it!=drawables.end()) {
+        return &it.value();
     }
 
     return NULL;
@@ -982,13 +985,15 @@ bool RGraphicsSceneQt::hasClipRectangleFor(REntity::Id entityId, bool preview) c
 
 RBox RGraphicsSceneQt::getClipRectangle(REntity::Id entityId, bool preview) const {
     if (preview) {
-        if (previewClipRectangles.contains(entityId)) {
-            return previewClipRectangles.value(entityId);
+        QMap<RObject::Id, RBox>::const_iterator it = previewClipRectangles.constFind(entityId);
+        if (it!=previewClipRectangles.constEnd()) {
+            return it.value();
         }
     }
     else {
-        if (clipRectangles.contains(entityId)) {
-            return clipRectangles.value(entityId);
+        QMap<RObject::Id, RBox>::const_iterator it = clipRectangles.constFind(entityId);
+        if (it!=clipRectangles.constEnd()) {
+            return it.value();
         }
     }
 
@@ -1104,8 +1109,9 @@ QList<REntity::Id> RGraphicsSceneQt::getPreviewEntityIds() {
 }
 
 QList<RGraphicsSceneDrawable>* RGraphicsSceneQt::getPreviewDrawables(RObject::Id entityId) {
-    if (previewDrawables.contains(entityId)) {
-        return &previewDrawables[entityId];
+    QMap<RObject::Id, QList<RGraphicsSceneDrawable> >::iterator it = previewDrawables.find(entityId);
+    if (it!=previewDrawables.end()) {
+        return &it.value();
     }
     return NULL;
 }


### PR DESCRIPTION
`RGraphicsSceneQt::getDrawables()` is called once per entity for every frame from `RGraphicsViewImage::paintEntityThread()`. It did:

```cpp
if (drawables.contains(entityId)) {   // O(log n) walk
    return &drawables[entityId];      // O(log n) walk again, and operator[] detaches
}
```

Two walks of a map that holds one entry per entity, plus the mutable `operator[]` which detaches. Replaced with a single `find()`. The same pattern was present in `getDrawablesList()`, `getClipRectangle()` and `getPreviewDrawables()`, so those got the same treatment (the two const ones use `constFind()` and no longer detach).

## Measured

With 100000 line entities, looking up the drawables of every entity (`qcadcanvasbench --parts`, 3 fastest of 5 runs):

| | |
|---|---|
| before | 6.9 / 7.2 / 7.3 ms |
| after | 6.1 / 6.4 / 6.5 ms |

Consistent, but **smaller than it looks in a profile**: the second lookup walks nodes the first one just pulled into cache, so removing it saves ~11%, not ~50%. In the frame time of a full update (~86ms for 100000 lines at 2480x1678) the difference is not measurable above noise.

So this is worth having as a strictly better implementation — it also removes the `// TODO: check should not be necessary` — but it is not the answer to update performance. For 100000 lines the traversal breaks down roughly as: spatial index query ~11ms, `orderBackToFront` ~8ms, `getDrawables` ~7ms, `isSelected`+`isSelectedWorkingSet` ~4ms, and ~42ms in the body of `paintDrawableThread`.

## Verification

Behaviour is identical by construction (the old code was guarded by `contains()`, so `operator[]` never inserted). Confirmed empirically: rendering the same document before and after produces the same drawing calls (100002 lines, 3 `stroke()` calls) for lines and for arcs.

Built and measured with `qcadgui` only, linked against the existing prebuilt libraries. QCAD's script test suite was not run (it needs a full application build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)