### PR TITLE
Query the working set state once per update, not per drawable

### DIFF
--- a/src/gui/RGraphicsViewImage.cpp
+++ b/src/gui/RGraphicsViewImage.cpp
@@ -62,6 +62,7 @@ RGraphicsViewImage::RGraphicsViewImage(QObject* parent)
       drawingScale(1.0),
       alphaEnabled(false),
       showOnlyPlottable(false),
+      editingWorkingSet(false),
       decorationWorker(NULL) {
 
     currentScale = 1.0;
@@ -1167,6 +1168,10 @@ void RGraphicsViewImage::paintEntitiesMulti(const RBox& queryBox) {
     colorCorrectionDisableForPrinting = RSettings::getColorCorrectionDisableForPrinting();
     colorThreshold = RSettings::getColorThreshold();
 
+    // constant while this update is rendered: querying it per drawable is
+    // expensive (document variables lookup with string construction):
+    editingWorkingSet = document->isEditingWorkingSet();
+
     updateTextHeightThreshold();
 
     //qDebug() << "RGraphicsViewImage::paintEntities: colorCorrection: " << colorCorrection;
@@ -1586,8 +1591,7 @@ void RGraphicsViewImage::paintDrawableThread(RGraphicsViewWorker* worker, RGraph
 
     bool workingSet = true;
     if (!isPrintingOrExporting() && !preview) {
-        RDocument* doc = getDocument();
-        if (doc->isEditingWorkingSet()) {
+        if (editingWorkingSet) {
             if (!drawable.isWorkingSet()) {
                 // fade out entities not in working set:
                 workingSet = false;

--- a/src/gui/RGraphicsViewImage.h
+++ b/src/gui/RGraphicsViewImage.h
@@ -482,6 +482,9 @@ protected:
 
     bool showOnlyPlottable;
 
+    //! cached per update: constant while one update is rendered
+    bool editingWorkingSet;
+
     QList<RGraphicsViewWorker*> workers;
     RGraphicsViewWorker* decorationWorker;
 };


### PR DESCRIPTION
Profiling `paintDrawableThread()` on a 100000 line update showed it dominated by a single call:

```cpp
bool workingSet = true;
if (!isPrintingOrExporting() && !preview) {
    RDocument* doc = getDocument();
    if (doc->isEditingWorkingSet()) {      // <- once per drawable
```

`RDocument::isEditingWorkingSet()` (RDocument.cpp:3591) queries the document variables and does up to two `hasCustomProperty()` lookups, constructing `QString`s from the string literals each time — so it allocates several times per call. At 100000 drawables per frame that is hundreds of thousands of allocations for a value that cannot change while one update is rendered.

Queried once in `paintEntitiesMulti()`, next to the existing per update settings (`colorCorrection`, `colorThreshold`, ...), and used from the cached member. That call site also covers the export path (`paintEntities()`) and the selected entity pass in `paintDocument()`.

## Measured

100000 line entities at 2480x1678, `qcadcanvasbench`, A/B with the same binary and only `libqcadgui` swapped:

| | before | after |
|---|---|---|
| canvas painter view | 90.4 ms | **82.9 ms** |
| QPainter view (1 thread) | 89.7 ms | **87.7 ms** |
| traversal only (`QCADCANVAS_PROFILE=2`) | 73.4 ms | **68.5 ms** |

## Next hot spot, for information

After this change the top of the profile is `QMap<int, QList<RGraphicsSceneDrawable>>::find()` from `RGraphicsSceneQt::getDrawables()` — a red-black tree walk over one entry per entity, done once per entity per frame (1033 samples, well ahead of the next entry).

The `drawables` member is only ever accessed by key: `insert`, `remove`, `clear`, `find`, `constFind`. Every iteration over it in the file is commented out (RGraphicsSceneQt.cpp:1177 and :1290), so nothing appears to depend on its ordering and a `QHash` would make those lookups O(1). That is a header change and therefore an ABI change requiring a full rebuild, so I have not made it — happy to if wanted.

Also still significant: `orderBackToFront()` (sort + `queryEntityDirect` per entity, ~9ms) runs every frame although draw order only changes with the document — there is a commented out `drawablesCache` with a TODO right above the call site (RGraphicsViewImage.cpp:1196).

🤖 Generated with [Claude Code](https://claude.com/claude-code)