### PR TITLE
REllipse: rewrite closest point search

### DIFF
--- a/src/core/math/REllipse.cpp
+++ b/src/core/math/REllipse.cpp
@@ -820,137 +820,210 @@ QList<RVector> REllipse::getPointCloud(double segmentLength) const {
 RVector REllipse::getVectorTo(const RVector& point, bool limited, double strictRange) const {
     Q_UNUSED(strictRange)
 
-    RVector ret = RVector::invalid;
+    if (!point.isValid()) {
+        return RVector::invalid;
+    }
 
     double ang = getAngle();
-    //double dDistance = RMAXDOUBLE;
-    bool swap = false;
-    bool majorSwap = false;
+    double a = getMajorRadius();
+    double b = getMinorRadius();
 
+    // point in the coordinate system of the ellipse
+    // (centre at the origin, major axis along the X axis):
     RVector normalized = (point - center).get2D().rotate(-ang);
+
+    // ratios greater than one are handled by swapping the two axes and
+    // swapping the result back at the end:
+    bool axisSwap = false;
+    if (a < b) {
+        double dum = a;
+        a = b;
+        b = dum;
+        normalized = RVector(normalized.y, normalized.x);
+        axisSwap = true;
+    }
+
+    double u = normalized.x;
+    double v = normalized.y;
+
+    // closest point on the ellipse, in the coordinate system above:
+    RVector ret = RVector::invalid;
 
     // second candidate, used for points on the major axis where the two closest
     // points on the ellipse are mirrored across that axis:
     RVector retAlt = RVector::invalid;
 
-    // special case: point in line with major axis. The Newton iteration below
-    // cannot be used there (it divides by zero), so the closest point is
-    // determined directly:
-    if (fabs(normalized.getAngle()) < RS::AngleTolerance ||
-        fabs(normalized.getAngle()) > 2*M_PI-RS::AngleTolerance ||
-        fabs(normalized.getAngle()-M_PI) < RS::AngleTolerance) {
+    if (a < RS::PointTolerance) {
+        // ellipse without extent: the centre is the only point:
+        ret = RVector(0.0, 0.0);
+    }
 
-        double dA = getMajorRadius();
-        double dB = getMinorRadius();
-        double dU = normalized.x;
+    else if (b < a*1.0e-7) {
+        // ellipse collapsed into a line segment along the major axis. The
+        // iteration below cannot be evaluated accurately for such ratios and
+        // the segment is a closer approximation than what it would return:
+        ret = RVector(qBound(-a, u, a), 0.0);
+    }
 
+    else if (fabs(v) < a*RS::PointTolerance) {
+        // special case: point in line with the major axis (centre included).
+        //
         // the end point of the major axis is the closest point on the ellipse
         // only for points at or beyond its centre of curvature. Closer to the
         // centre of the ellipse the two closest points lie off the major axis
         // (for a point at the centre they are the end points of the minor axis):
-        double dLimit = (dA*dA - dB*dB) / dA;
+        double dLimit = (a*a - b*b) / a;
 
-        if (fabs(dU) >= dLimit) {
-            ret = RVector(dU>=0.0 ? dA : -dA, 0.0);
+        if (fabs(u) >= dLimit) {
+            ret = RVector(u>=0.0 ? a : -a, 0.0);
         }
         else {
-            double dX = (dA*dA * dU) / (dA*dA - dB*dB);
-            double dY = dB * sqrt(qMax(1.0 - (dX*dX)/(dA*dA), 0.0));
-            ret = RVector(dX, dY);
-            retAlt = RVector(dX, -dY);
+            double x = (a*a * u) / (a*a - b*b);
+            double y = b * sqrt(qMax(1.0 - (x*x)/(a*a), 0.0));
+            ret = RVector(x, y);
+            retAlt = RVector(x, -y);
         }
-        //dDistance = ret.distanceTo(normalized);
+    }
+
+    else if (fabs(u) < a*RS::PointTolerance) {
+        // special case: point in line with the minor axis (centre excluded
+        // above). The centre of curvature of an end point of the minor axis
+        // always lies beyond the centre of the ellipse, so the closer end
+        // point of the minor axis is the closest point on the ellipse:
+        ret = RVector(0.0, v>=0.0 ? b : -b);
     }
 
     else {
-        double dU = normalized.x;
-        double dV = normalized.y;
-        double dA = getMajorRadius();
-        double dB = getMinorRadius();
-        double dEpsilon = 1.0e-8;
-        // iteration maximum
-        int iMax = 32;
-        double rdX = 0.0;
-        double rdY = 0.0;
+        // general case:
+        //
+        // fixed point iteration which exploits the evolute of the ellipse and
+        // needs no trigonometric functions, followed by a Newton refinement of
+        // the parametric angle. Contributed by CVH, based on the method of
+        // Carl Chatfield and a trigonometry free variant of it by
+        // Adrian Stephens:
+        // https://blog.chatfield.io/simple-method-for-distance-to-ellipse/
+        // https://github.com/0xfaded/ellipse_demo/issues/1
 
-        if (dA<dB) {
-            double dum = dA;
-            dA = dB;
-            dB = dum;
-            dum = dU;
-            dU = dV;
-            dV = dum;
-            majorSwap = true;
-        }
+        // solved in the first quadrant, for an ellipse scaled down by the major
+        // radius (major radius 1, minor radius rb):
+        double px = fabs(u) / a;
+        double py = fabs(v) / a;
+        double rb = b / a;
 
-        if (dV<0.0) {
-            dV*=-1.0;
-            swap = true;
-        }
+        // the two factors of the evolute of the scaled down ellipse,
+        // (a*a - b*b)/a and (b*b - a*a)/b for a==1:
+        double ea = 1.0 - rb*rb;
+        double eb = rb - 1.0/rb;
 
-        // initial guess:
-        double dT = dB*(dV - dB);
+        // parameter of the current approximation, as a (cos, sin) pair:
+        double tx = 0.7071067811865476;
+        double ty = 0.7071067811865476;
+        // current approximation of the closest point:
+        double nx = tx;
+        double ny = rb * ty;
 
-        // newton's method:
-        int i;
-        for (i = 0; i < iMax; i++) {
-            double dTpASqr = dT + dA*dA;
-            double dTpBSqr = dT + dB*dB;
-            double dInvTpASqr = 1.0/dTpASqr;
-            double dInvTpBSqr = 1.0/dTpBSqr;
-            double dXDivA = dA*dU*dInvTpASqr;
-            double dYDivB = dB*dV*dInvTpBSqr;
-            double dXDivASqr = dXDivA*dXDivA;
-            double dYDivBSqr = dYDivB*dYDivB;
-            double dF = dXDivASqr + dYDivBSqr - 1.0;
-            if (fabs(dF) < dEpsilon) {
-                // f(t0) is very close to zero:
-                rdX = dXDivA*dA;
-                rdY = dYDivB*dB;
+        for (int i=0; i<32; i++) {
+            double x = nx;
+            double y = ny;
+
+            // centre of curvature for the current parameter:
+            double ex = ea * tx*tx*tx;
+            double ey = eb * ty*ty*ty;
+
+            // vector from there to the current approximation
+            // (the radius of curvature) and to the given point:
+            double rx = x - ex;
+            double ry = y - ey;
+            double qx = px - ex;
+            double qy = py - ey;
+
+            double q = qx*qx + qy*qy;
+            if (q < RS::PointTolerance*RS::PointTolerance) {
+                // point coincides with the centre of curvature:
                 break;
             }
-            double dFDer = 2.0*(dXDivASqr*dInvTpASqr + dYDivBSqr*dInvTpBSqr);
 
-            double dRatio = dF/dFDer;
+            // scale the vector to the given point to the radius of curvature
+            // to get the next approximation:
+            double f = sqrt((rx*rx + ry*ry) / q);
+            tx = qBound(0.0, qx*f + ex, 1.0);
+            ty = qBound(0.0, (qy*f + ey) / rb, 1.0);
 
-            if ( fabs(dRatio) < dEpsilon ) {
-                // t1-t0 is very close to zero:
-                rdX = dXDivA*dA;
-                rdY = dYDivB*dB;
+            double t = sqrt(tx*tx + ty*ty);
+            if (t < RS::PointTolerance) {
                 break;
             }
-            dT += dRatio;
+            tx /= t;
+            ty /= t;
+
+            nx = tx;
+            ny = rb * ty;
+
+            if (fabs(nx-x) < 1.0e-10 && fabs(ny-y) < 1.0e-10) {
+                // close enough for the refinement below:
+                break;
+            }
         }
 
-        if (i == iMax) {
-            // failed to converge:
-            //dDistance = RMAXDOUBLE;
-            ret = RVector::invalid;
+        // refine the parametric angle t of the approximation with Newton's
+        // method on the derivative of the squared distance to the given point:
+        // h(t) = (b*b - a*a)/2 * sin(2t) + a*|u|*sin(t) - b*|v|*cos(t)
+        // (expanded below using sin(2t) = 2*sin(t)*cos(t) and
+        // cos(2t) = cos(t)^2 - sin(t)^2). This recovers full precision also for
+        // eccentric ellipses, for which the iteration above converges slowly:
+        double su = fabs(u);
+        double sv = fabs(v);
+        double bma = b*b - a*a;
+        double t = atan2(ty, tx);
+        for (int i=0; i<2; i++) {
+            double s = sin(t);
+            double c = cos(t);
+            double h = bma*s*c + a*su*s - b*sv*c;
+            double hd = bma*(c*c - s*s) + a*su*c + b*sv*s;
+            if (hd==0.0) {
+                break;
+            }
+            double dt = h/hd;
+            if (!RMath::isNormal(dt) || fabs(dt)>0.1) {
+                // implausible step, keep the result of the iteration above:
+                break;
+            }
+            t -= dt;
+            if (fabs(dt) < 1.0e-14) {
+                // converged:
+                break;
+            }
         }
-        else {
-            //double dDelta0 = rdX - dU;
-            //double dDelta1 = rdY - dV;
-            //dDistance = sqrt(dDelta0*dDelta0 + dDelta1*dDelta1);
-            ret = RVector(rdX, rdY);
+
+        ret = RVector(a*cos(t), b*sin(t));
+
+        // mirror the result back into the quadrant of the given point:
+        if (u < 0.0) {
+            ret.x = -ret.x;
+        }
+        if (v < 0.0) {
+            ret.y = -ret.y;
         }
     }
 
     if (ret.isValid()) {
-        if (swap) {
-            ret.y*=-1.0;
-        }
-        if (majorSwap) {
+        if (axisSwap) {
             double dum = ret.x;
             ret.x = ret.y;
             ret.y = dum;
+            if (retAlt.isValid()) {
+                dum = retAlt.x;
+                retAlt.x = retAlt.y;
+                retAlt.y = dum;
+            }
         }
         ret = (ret.rotate(ang) + center);
 
         if (limited) {
             double a1 = center.getAngleTo(getStartPoint());
             double a2 = center.getAngleTo(getEndPoint());
-            double a = center.getAngleTo(ret);
-            if (!RMath::isAngleBetween(a, a1, a2, reversed)) {
+            double aRet = center.getAngleTo(ret);
+            if (!RMath::isAngleBetween(aRet, a1, a2, reversed)) {
                 ret = RVector::invalid;
 
                 // the mirrored closest point may still be on this ellipse arc:
@@ -963,25 +1036,6 @@ RVector REllipse::getVectorTo(const RVector& point, bool limited, double strictR
             }
         }
     }
-
-    /*
-    if (dist!=NULL) {
-        if (ret.valid) {
-            *dist = dDistance;
-        } else {
-            *dist = RS_MAXDOUBLE;
-        }
-    }
-
-    if (entity!=NULL) {
-        if (ret.valid) {
-            *entity = this;
-        }
-        else {
-            *entity = NULL;
-        }
-    }
-    */
 
     return point - ret;
 }

--- a/src/core/math/REllipse.cpp
+++ b/src/core/math/REllipse.cpp
@@ -817,6 +817,24 @@ QList<RVector> REllipse::getPointCloud(double segmentLength) const {
     return pl.getPointCloud(segmentLength);
 }
 
+/**
+ * \return Vector from the closest point on this ellipse to the given point or
+ *      an invalid vector if there is no such point.
+ *
+ * \param limited True to only consider the ellipse arc from start to end
+ *      parameter, false to consider the full ellipse.
+ *
+ * The closest point is found with a fixed point iteration which exploits the
+ * evolute of the ellipse and needs no trigonometric functions, followed by a
+ * Newton refinement of the parametric angle. Points in line with one of the two
+ * axes and degenerate ellipses are handled separately.
+ *
+ * The iteration was contributed as a proof of concept by CVH, based on the
+ * method of Carl Chatfield and a trigonometry free variant of it by
+ * Adrian Stephens:
+ * https://blog.chatfield.io/simple-method-for-distance-to-ellipse/
+ * https://github.com/0xfaded/ellipse_demo/issues/1
+ */
 RVector REllipse::getVectorTo(const RVector& point, bool limited, double strictRange) const {
     Q_UNUSED(strictRange)
 
@@ -894,18 +912,9 @@ RVector REllipse::getVectorTo(const RVector& point, bool limited, double strictR
     }
 
     else {
-        // general case:
-        //
-        // fixed point iteration which exploits the evolute of the ellipse and
-        // needs no trigonometric functions, followed by a Newton refinement of
-        // the parametric angle. Contributed by CVH, based on the method of
-        // Carl Chatfield and a trigonometry free variant of it by
-        // Adrian Stephens:
-        // https://blog.chatfield.io/simple-method-for-distance-to-ellipse/
-        // https://github.com/0xfaded/ellipse_demo/issues/1
-
-        // solved in the first quadrant, for an ellipse scaled down by the major
-        // radius (major radius 1, minor radius rb):
+        // general case: the fixed point iteration credited above, solved in the
+        // first quadrant for an ellipse scaled down by the major radius
+        // (major radius 1, minor radius rb):
         double px = fabs(u) / a;
         double py = fabs(v) / a;
         double rb = b / a;

--- a/src/core/math/REllipse.cpp
+++ b/src/core/math/REllipse.cpp
@@ -829,9 +829,10 @@ QList<RVector> REllipse::getPointCloud(double segmentLength) const {
  * Newton refinement of the parametric angle. Points in line with one of the two
  * axes and degenerate ellipses are handled separately.
  *
- * The iteration was contributed as a proof of concept by CVH, based on the
- * method of Carl Chatfield and a trigonometry free variant of it by
- * Adrian Stephens:
+ * The iteration was contributed as a proof of concept by CVH in the QCAD forum
+ * thread "REllipse.getVectorTo(p) exceptions (FS#2564)", based on the method of
+ * Carl Chatfield and a trigonometry free variant of it by Adrian Stephens:
+ * https://forum.qcad.org/t/rellipse-getvectorto-p-exceptions-fs-2564/9284
  * https://blog.chatfield.io/simple-method-for-distance-to-ellipse/
  * https://github.com/0xfaded/ellipse_demo/issues/1
  */


### PR DESCRIPTION
Based on the proof of concept contributed by **CVH** (`POC_NearestPointOnEllipse.js`) in
[REllipse.getVectorTo(p) exceptions (FS#2564)](https://forum.qcad.org/t/rellipse-getvectorto-p-exceptions-fs-2564/9284).

## The problem

`REllipse::getVectorTo()` solves for the closest point with Newton's method on

```
f(t) = (a*u/(t+a^2))^2 + (b*v/(t+b^2))^2 - 1
```

starting from `t0 = b*(v-b)`. From that starting point the iteration converges to
a wrong root for points close to the major axis and for points near the evolute:
it then returns a point that is not on the ellipse at all. It also stops as soon
as `|f| < 1e-8`, which limits the accuracy even where it does converge, because
`f` is flat near the solution.

Measured against a 60 digit reference (bisection on the equation above, which is
strictly monotonic on `t > -b^2`), as a fraction of the major radius:

| regime | worst | mean |
|---|---|---|
| points near the major axis | **3.0** | 2.5e-2 |
| points near the evolute | 6.5e-4 | 2.4e-6 |
| eccentric ellipses | 2.4e-1 | 4.1e-4 |
| general | 5.5e-5 | 4.2e-7 |

A worst case of 3.0 means the returned point is three major radii away from the
closest point on the ellipse.

## The change

The contributed method: a fixed point iteration that exploits the evolute of the
ellipse, needs no trigonometric functions, and is applied to the ellipse scaled
down to a major radius of one. It is due to Carl Chatfield, in the trigonometry
free variant by Adrian Stephens
([blog](https://blog.chatfield.io/simple-method-for-distance-to-ellipse/),
[code](https://github.com/0xfaded/ellipse_demo/issues/1), MIT).

Two things were added on top of the proof of concept:

* **A Newton refinement of the parametric angle** on `h(t) = (b^2-a^2)/2*sin(2t)
  + a|u|sin(t) - b|v|cos(t)`, the derivative of the squared distance. The
  iteration alone converges slowly for eccentric ellipses and is off by up to
  5.6e-4 there; two refinement steps bring that to 3.8e-13. The iteration
  supplies the globally correct starting point, the refinement supplies the
  precision.
* **Cases that were not handled before**: degenerate ellipses (ratio 0 or major
  radius 0) returned an invalid vector, ellipses with a ratio greater than one
  took a shortcut for points on the axes that is only correct for a ratio below
  one, and points in line with the minor axis are now answered directly.

The existing handling of points in line with the major axis is kept, including
the mirrored second candidate that may still lie on an ellipse arc. Its
tolerance is now relative to the major radius, so it behaves the same for small
ellipses as for large ones (it used to be an angular tolerance).

## Verification

Every number below is from the actual compiled `REllipse`, before and after,
linked against a standalone harness (not committed).

Worst relative error, 4600 random cases over 8 regimes, random centre and
rotation, compared with the 60 digit reference:

| regime | master | this branch |
|---|---|---|
| general | 5.500e-05 | 5.868e-12 |
| near curve | 1.755e-06 | 7.181e-13 |
| near evolute | 6.539e-04 | 1.599e-11 |
| near major axis | 2.975e+00 | 2.202e-09 |
| near minor axis | 4.768e-09 | 9.993e-10 |
| eccentric | 2.434e-01 | 3.765e-13 |
| near circular | 1.036e-06 | 1.020e-12 |
| far away | 4.785e-09 | 1.149e-10 |
| **overall worst** | **2.975e+00** | **2.202e-09** |

The residual ~1e-9 for the two axis regimes is the deliberate snapping of points
within `RS::PointTolerance` of an axis onto that axis.

**Ellipse arcs** (`limited=true`), 4000 random arcs and points: the result is
valid in exactly the same 1971 cases as before, invalid in the same 2029 — the
arc semantics are unchanged. Where both are valid, the new point is never
further from the given point than master's; measured against a brute force scan
of the arc, master overshoots by up to 1.2e-8 and this branch by 0.

**Ratio > 1** (axis swap), 3000 cases, worst `|x^2/a^2 + y^2/b^2 - 1|` of the
returned point: master 4.2e-05, this branch 3.3e-13.

**Degenerate ellipses**, 200 cases each, no NaN or Inf in either version:

| ellipse | master | this branch |
|---|---|---|
| ratio 0 | invalid for all 200 | segment, deviation 3.6e-15 |
| ratio 1e-12 | off the axis by 1e-11 | 3.6e-15 |
| ratio 1e-8 | off the axis by 1e-7 | 3.6e-15 |
| major radius 0 | invalid for all 200 | centre |
| circle | 9.8e-09 | 8.9e-16 |

**Cost**: 192ns -> 268ns per call (300k calls, release build). The refinement
uses the double angle identities and stops early, and the iteration only runs
until it is within 1e-10 since the refinement converges quadratically from
there; without those it was 321ns.

## Note on the proof of concept

The near circular shortcut in `getNearestPointsOnFullREllipse2D()` references an
undefined `majorR` (the variable is named `a`), so that branch throws. It is not
reachable in the driver code. No shortcut for near circular ellipses was needed
here — the iteration converges on them in a single step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
