### PR TITLE
RGraphicsSceneQt: hash instead of map for the document drawables

### DIFF
--- a/src/gui/RGraphicsSceneQt.cpp
+++ b/src/gui/RGraphicsSceneQt.cpp
@@ -952,7 +952,7 @@ void RGraphicsSceneQt::deleteDrawables() {
 }
 
 QList<RGraphicsSceneDrawable> RGraphicsSceneQt::getDrawablesList(REntity::Id entityId) {
-    QMap<RObject::Id, QList<RGraphicsSceneDrawable> >::const_iterator it = drawables.constFind(entityId);
+    QHash<RObject::Id, QList<RGraphicsSceneDrawable> >::const_iterator it = drawables.constFind(entityId);
     if (it!=drawables.constEnd()) {
         return it.value();
     }
@@ -966,7 +966,7 @@ QList<RGraphicsSceneDrawable> RGraphicsSceneQt::getDrawablesList(REntity::Id ent
 QList<RGraphicsSceneDrawable>* RGraphicsSceneQt::getDrawables(REntity::Id entityId) {
     // one lookup instead of two: this is called for every entity of every
     // frame, contains() followed by operator[] walks the map twice:
-    QMap<RObject::Id, QList<RGraphicsSceneDrawable> >::iterator it = drawables.find(entityId);
+    QHash<RObject::Id, QList<RGraphicsSceneDrawable> >::iterator it = drawables.find(entityId);
     if (it!=drawables.end()) {
         return &it.value();
     }
@@ -991,7 +991,7 @@ RBox RGraphicsSceneQt::getClipRectangle(REntity::Id entityId, bool preview) cons
         }
     }
     else {
-        QMap<RObject::Id, RBox>::const_iterator it = clipRectangles.constFind(entityId);
+        QHash<RObject::Id, RBox>::const_iterator it = clipRectangles.constFind(entityId);
         if (it!=clipRectangles.constEnd()) {
             return it.value();
         }
@@ -1071,19 +1071,25 @@ void RGraphicsSceneQt::addDrawable(REntity::Id entityId, RGraphicsSceneDrawable&
         }
     }
 
-    QMap<REntity::Id, QList<RGraphicsSceneDrawable> >* dwb;
+    // preview drawables are kept in a map (ordered keys), the drawables of
+    // the document in a hash (faster lookup):
     if (preview) {
-        dwb = &previewDrawables;
+        QMap<REntity::Id, QList<RGraphicsSceneDrawable> >::iterator it = previewDrawables.find(entityId);
+        if (it!=previewDrawables.end()) {
+            it.value().append(drawable);
+        }
+        else {
+            previewDrawables.insert(entityId, QList<RGraphicsSceneDrawable>() << drawable);
+        }
     }
     else {
-        dwb = &drawables;
-    }
-
-    if (dwb->contains(entityId)) {
-        (*dwb)[entityId].append(drawable);
-    }
-    else {
-        dwb->insert(entityId, QList<RGraphicsSceneDrawable>() << drawable);
+        QHash<REntity::Id, QList<RGraphicsSceneDrawable> >::iterator it = drawables.find(entityId);
+        if (it!=drawables.end()) {
+            it.value().append(drawable);
+        }
+        else {
+            drawables.insert(entityId, QList<RGraphicsSceneDrawable>() << drawable);
+        }
     }
 }
 

--- a/src/gui/RGraphicsSceneQt.h
+++ b/src/gui/RGraphicsSceneQt.h
@@ -23,6 +23,7 @@
 #include "gui_global.h"
 
 #include <QList>
+#include <QHash>
 #include <QMultiMap>
 
 #include "RGraphicsScene.h"
@@ -175,9 +176,12 @@ protected:
 
 private:
 
-    QMap<RObject::Id, QList<RGraphicsSceneDrawable> > drawables;
-    QMap<RObject::Id, RBox> clipRectangles;
+    // looked up by entity ID once per entity per frame, never iterated:
+    // a hash keeps those lookups constant time
+    QHash<RObject::Id, QList<RGraphicsSceneDrawable> > drawables;
+    QHash<RObject::Id, RBox> clipRectangles;
 
+    // getPreviewEntityIds() relies on keys() being ordered: keep these maps
     QMap<RObject::Id, QList<RGraphicsSceneDrawable> > previewDrawables;
     QMap<RObject::Id, RBox> previewClipRectangles;
 

--- a/src/gui/RGraphicsViewImage.cpp
+++ b/src/gui/RGraphicsViewImage.cpp
@@ -62,6 +62,7 @@ RGraphicsViewImage::RGraphicsViewImage(QObject* parent)
       drawingScale(1.0),
       alphaEnabled(false),
       showOnlyPlottable(false),
+      editingWorkingSet(false),
       decorationWorker(NULL) {
 
     currentScale = 1.0;
@@ -1167,6 +1168,10 @@ void RGraphicsViewImage::paintEntitiesMulti(const RBox& queryBox) {
     colorCorrectionDisableForPrinting = RSettings::getColorCorrectionDisableForPrinting();
     colorThreshold = RSettings::getColorThreshold();
 
+    // constant while this update is rendered: querying it per drawable is
+    // expensive (document variables lookup with string construction):
+    editingWorkingSet = document->isEditingWorkingSet();
+
     updateTextHeightThreshold();
 
     //qDebug() << "RGraphicsViewImage::paintEntities: colorCorrection: " << colorCorrection;
@@ -1586,8 +1591,7 @@ void RGraphicsViewImage::paintDrawableThread(RGraphicsViewWorker* worker, RGraph
 
     bool workingSet = true;
     if (!isPrintingOrExporting() && !preview) {
-        RDocument* doc = getDocument();
-        if (doc->isEditingWorkingSet()) {
+        if (editingWorkingSet) {
             if (!drawable.isWorkingSet()) {
                 // fade out entities not in working set:
                 workingSet = false;

--- a/src/gui/RGraphicsViewImage.h
+++ b/src/gui/RGraphicsViewImage.h
@@ -482,6 +482,9 @@ protected:
 
     bool showOnlyPlottable;
 
+    //! cached per update: constant while one update is rendered
+    bool editingWorkingSet;
+
     QList<RGraphicsViewWorker*> workers;
     RGraphicsViewWorker* decorationWorker;
 };


### PR DESCRIPTION
Stacked on #204 (the working set fix), since the measurements below build on it. `RGraphicsSceneQt.*` and `RGraphicsViewImage.*` are disjoint, so the two do not conflict.

After #204, the top of the profile for a 100000 line update was `QMap<int, QList<RGraphicsSceneDrawable>>::find()` from `RGraphicsSceneQt::getDrawables()`, called once per entity per frame — a red-black tree walk over one entry per entity.

`drawables` and `clipRectangles` are only ever accessed by key (`insert`, `remove`, `clear`, `find`, `constFind`, and a merge of another container) and are never iterated — every iteration over them in the file is commented out (RGraphicsSceneQt.cpp:1177, :1290). So they can be `QHash`.

**`previewDrawables` and `previewClipRectangles` stay `QMap`**: `getPreviewEntityIds()` calls `keys()` on both and its comment states it must not change the order. `QHash::keys()` is unordered, so converting those would have silently reordered preview drawing.

`addDrawable()` also used `contains()` followed by `operator[]`; that is a single `find()` now too.

## Measured

100000 line entities at 2480x1678. All three configurations built from source with identical flags, each with a benchmark compiled against its own headers (this is an ABI change, so a stale benchmark would be undefined behaviour), and the runs interleaved to cancel thermal drift.

Traversal only (`QCADCANVAS_PROFILE=2`), 4 interleaved rounds:

| | r1 | r2 | r3 | r4 | median |
|---|---|---|---|---|---|
| master (#203) | 76.8 | 78.2 | 74.3 | 78.5 | 77.5 ms |
| + #204 | 67.9 | 67.3 | 65.7 | 69.8 | **67.6 ms** |
| + this PR | 56.3 | 55.6 | 52.6 | 56.3 | **56.0 ms** |

Full update, 3 interleaved rounds (best of 5 each):

| | canvas painter | QPainter, 1 thread |
|---|---|---|
| master (#203) | 88.9 ms | 92.3 ms |
| + #204 | 82.4 ms | 84.6 ms |
| + this PR | **71.8 ms** | **73.5 ms** |

So this PR is worth about 11ms of traversal on its own, and #204 plus this one take a 100000 line update from ~89ms to ~72ms with the canvas painter and from ~92ms to ~74ms with QPainter — roughly 20% for both backends.

## Verification

Rendering is unchanged: the same document produces the same drawing calls before and after (100002 lines / 3 `stroke()` calls for lines, 260002 lines / 7 `stroke()` calls for arcs).

QCAD's script test suite was not run (it needs a full application build); `qcadgui` was built and measured against the existing prebuilt libraries.

Note for reviewers: this changes a header, so dependents must be rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)