### PR TITLE
Reuse the ordered list of visible entities between updates

### DIFF
--- a/src/gui/RGraphicsSceneQt.cpp
+++ b/src/gui/RGraphicsSceneQt.cpp
@@ -44,6 +44,7 @@
 
 RGraphicsSceneQt::RGraphicsSceneQt(RDocumentInterface& documentInterface) :
     RGraphicsScene(documentInterface),
+    drawablesVersion(0),
     decorating(false),
     screenBasedLinetypesOverride(false) {
 
@@ -940,12 +941,14 @@ void RGraphicsSceneQt::unexportEntity(REntity::Id entityId) {
     if (!exportToPreview) {
         drawables.remove(entityId);
         clipRectangles.remove(entityId);
+        drawablesVersion++;
     }
 }
 
 void RGraphicsSceneQt::deleteDrawables() {
     drawables.clear();
     clipRectangles.clear();
+    drawablesVersion++;
 
     previewDrawables.clear();
     previewClipRectangles.clear();
@@ -1090,6 +1093,7 @@ void RGraphicsSceneQt::addDrawable(REntity::Id entityId, RGraphicsSceneDrawable&
         else {
             drawables.insert(entityId, QList<RGraphicsSceneDrawable>() << drawable);
         }
+        drawablesVersion++;
     }
 }
 

--- a/src/gui/RGraphicsSceneQt.h
+++ b/src/gui/RGraphicsSceneQt.h
@@ -90,6 +90,14 @@ public:
     
     virtual void unexportEntity(RObject::Id entityId);
 
+    /**
+     * \return A number which changes whenever the drawables of the document
+     * change. Used to invalidate caches which depend on them.
+     */
+    int getDrawablesVersion() const {
+        return drawablesVersion;
+    }
+
     virtual void exportPoint(const RPoint& point);
     virtual double exportLine(const RLine& line, double offset = RNANDOUBLE);
     virtual void exportArc(const RArc& arc, double offset = RNANDOUBLE);
@@ -178,6 +186,9 @@ private:
 
     // looked up by entity ID once per entity per frame, never iterated:
     // a hash keeps those lookups constant time
+    //! bumped whenever the drawables of the document change
+    int drawablesVersion;
+
     QHash<RObject::Id, QList<RGraphicsSceneDrawable> > drawables;
     QHash<RObject::Id, RBox> clipRectangles;
 

--- a/src/gui/RGraphicsViewImage.cpp
+++ b/src/gui/RGraphicsViewImage.cpp
@@ -63,6 +63,8 @@ RGraphicsViewImage::RGraphicsViewImage(QObject* parent)
       alphaEnabled(false),
       showOnlyPlottable(false),
       editingWorkingSet(false),
+      orderedIdsVersion(-1),
+      orderedIdsValid(false),
       decorationWorker(NULL) {
 
     currentScale = 1.0;
@@ -1187,8 +1189,30 @@ void RGraphicsViewImage::paintEntitiesMulti(const RBox& queryBox) {
 
     //RDebug::startTimer(60);
     //mutexSi.lock();
-    QSet<RObject::Id> ids;
-    ids = document->queryIntersectedEntitiesXYFast(qb);
+    // querying the spatial index and ordering the result is expensive and
+    // depends only on the query box and on the drawables of the scene, so the
+    // result is reused while neither changes (e.g. when only the cursor, the
+    // preview or the selection changed):
+    bool orderedIdsUsable =
+        !isPrintingOrExporting() &&
+        orderedIdsValid &&
+        sceneQt!=NULL &&
+        orderedIdsVersion==sceneQt->getDrawablesVersion() &&
+        orderedIdsBox.equalsFuzzy(qb);
+
+    QList<RObject::Id> list;
+    if (orderedIdsUsable) {
+        list = orderedIds;
+    }
+    else {
+        QSet<RObject::Id> ids;
+        ids = document->queryIntersectedEntitiesXYFast(qb);
+        list = document->getStorage().orderBackToFront(ids);
+
+        orderedIds = list;
+        orderedIdsBox = qb;
+        orderedIdsValid = !isPrintingOrExporting();
+    }
     //qDebug() << "RGraphicsViewImage::paintEntities: ids: " << ids;
     //mutexSi.unlock();
     //RDebug::stopTimer(60, "spatial index");
@@ -1227,10 +1251,7 @@ void RGraphicsViewImage::paintEntitiesMulti(const RBox& queryBox) {
     }
     */
 
-    //RDebug::startTimer(60);
-    QList<RObject::Id> list = document->getStorage().orderBackToFront(ids);
-    //QList<RObject::Id> list = ids.toList();
-    //RDebug::stopTimer(60, "ordering");
+
 
     // about 30ms for 50000:
 //    RDebug::startTimer(60);
@@ -1311,6 +1332,13 @@ void RGraphicsViewImage::paintEntitiesMulti(const RBox& queryBox) {
         }
     }
     //RDebug::stopTimer(61, "regen");
+
+    // the loop above may have regenerated drawables: remember the version the
+    // cached list of entities is valid for only now, so that the next update
+    // can reuse it:
+    if (orderedIdsValid && sceneQt!=NULL) {
+        orderedIdsVersion = sceneQt->getDrawablesVersion();
+    }
 
     if (numThreads==1) {
         RGraphicsViewWorker* worker = workers[0];

--- a/src/gui/RGraphicsViewImage.h
+++ b/src/gui/RGraphicsViewImage.h
@@ -485,6 +485,12 @@ protected:
     //! cached per update: constant while one update is rendered
     bool editingWorkingSet;
 
+    //! cached list of visible entities in draw order and what it is valid for
+    QList<RObject::Id> orderedIds;
+    RBox orderedIdsBox;
+    int orderedIdsVersion;
+    bool orderedIdsValid;
+
     QList<RGraphicsViewWorker*> workers;
     RGraphicsViewWorker* decorationWorker;
 };


### PR DESCRIPTION
`paintEntitiesMulti()` queries the spatial index and orders the result back to front on **every** update. For 100000 entities that is ~13ms for the query and ~9ms for the ordering per frame, although the result depends only on the query box and on the drawables of the scene.

This caches the ordered list in the view and reuses it while both are unchanged.

`RGraphicsSceneQt` gets a `drawablesVersion` counter, bumped whenever the drawables of the document change (`addDrawable`, `unexportEntity`, `deleteDrawables`), so any regeneration of the scene invalidates the cache. The version is recorded *after* the regeneration loop in `paintEntitiesMulti()` (that loop can itself export entities), so the following update can reuse the list. The cache is disabled while printing or exporting.

## Measured

100000 line entities at 2480x1678, both configurations built from source with identical flags, benchmarks compiled against their own headers, runs interleaved:

| | traversal (`PROFILE=2`) | full update |
|---|---|---|
| master | 55.6 / 54.5 / 54.7 / 58.4 ms | 68.8 / 71.9 / 70.3 / 76.1 ms |
| this PR | **40.5 / 44.1 / 45.6 / 42.3 ms** | **58.5 / 58.8 / 62.0 / 62.0 ms** |

Medians: traversal 55.2 -> 43.2 ms, full update 71.1 -> 60.4 ms.

## Verification

The benchmark alone cannot test this, because it never modifies the document. A separate test renders, then adds geometry and regenerates the scene, then renders again:

- the drawables version changes after the edit (1000 -> 2000)
- geometry added **after** the first update is drawn (both halves of the image contain painted pixels)
- pixel counts are identical to a master build (2308 / 827), i.e. rendering is unchanged

## What reviewers should check

The cache assumes that anything which changes either the set of visible entities or their draw order also changes the drawables of the scene. That holds for edits, layer changes and draw order changes, which all regenerate the scene. If there is a path which changes entity geometry or draw order **without** re-exporting drawables, the cached list would be stale until the next regeneration — that is the one assumption worth a second opinion, and I could not run QCAD's script test suite here (it needs a full application build).

## Also tried and rejected

Inlining the comparison of `orderBackToFront()` (`std::sort` is given the static member `lessThan`, which decays to a function pointer) plus reserving both lists: measured over 4 interleaved rounds it gives ~0.9ms, inside the noise, and no traversal improvement. The indirect call is perfectly predicted, so it is not worth a change. Not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)