### PR TITLE
Reduce copying and call overhead in the paint loop

### DIFF
--- a/src/core/RPainterPath.cpp
+++ b/src/core/RPainterPath.cpp
@@ -606,7 +606,7 @@ void RPainterPath::addPoint(const RVector& position) {
 }
 
 
-bool RPainterPath::hasPoints() {
+bool RPainterPath::hasPoints() const {
     return points.count()!=0;
 }
 

--- a/src/core/RPainterPath.h
+++ b/src/core/RPainterPath.h
@@ -254,6 +254,13 @@ public:
 
     void addPoint(const RVector& position);
     bool hasPoints();
+    /**
+     * Const overload. The non const one is kept as it is: it is part of the
+     * exported interface and referenced by the script bindings.
+     */
+    bool hasPoints() const {
+        return points.count()!=0;
+    }
     void setPoints(const QList<RVector>& p);
     QList<RVector> getPoints() const;
 

--- a/src/core/RPainterPath.h
+++ b/src/core/RPainterPath.h
@@ -253,14 +253,7 @@ public:
     double getDistanceTo(const RVector& point) const;
 
     void addPoint(const RVector& position);
-    bool hasPoints();
-    /**
-     * Const overload. The non const one is kept as it is: it is part of the
-     * exported interface and referenced by the script bindings.
-     */
-    bool hasPoints() const {
-        return points.count()!=0;
-    }
+    bool hasPoints() const;
     void setPoints(const QList<RVector>& p);
     QList<RVector> getPoints() const;
 

--- a/src/core/math/RMath.cpp
+++ b/src/core/math/RMath.cpp
@@ -121,9 +121,7 @@ double RMath::pow(double x, double y) {
 /**
  * \return true if v is non NaN and not Inf.
  */
-bool RMath::isNormal(double v) {
-    return isSane(v);
-}
+
 
 /**
  * \return true if v is NaN.
@@ -152,9 +150,7 @@ bool RMath::isInf(double v) {
 #endif
 }
 
-bool RMath::isSane(double v) {
-    return !isNaN(v) && !isInf(v);
-}
+
 
 /**
  * Evaluates the given mathematical expression and returns the result.

--- a/src/core/math/RMath.h
+++ b/src/core/math/RMath.h
@@ -116,11 +116,23 @@ public:
 
     static double pow(double x, double y);
 
-    static bool isNormal(double v);
     static bool isNaN(double v);
     static bool isInf(double v);
 
-    static bool isSane(double v);
+    /**
+     * \return True if v is neither NaN nor Inf.
+     *
+     * Inline: this is called for every coordinate of every path of every
+     * frame. std::isfinite is exactly the condition of !isNaN(v) && !isInf(v)
+     * for all platform variants of those two.
+     */
+    static bool isSane(double v) {
+        return std::isfinite(v);
+    }
+
+    static bool isNormal(double v) {
+        return isSane(v);
+    }
 
     static double eval(const QString& expression, bool* ok = NULL);
     static QString getError();

--- a/src/gui/RGraphicsViewImage.cpp
+++ b/src/gui/RGraphicsViewImage.cpp
@@ -1597,11 +1597,12 @@ void RGraphicsViewImage::paintEntityThread(RGraphicsViewWorker* worker, RObject:
     }
 
     // paint drawables (painter paths, texts, images):
-    QListIterator<RGraphicsSceneDrawable> i(*drawables);
-    while (i.hasNext()) {
-        RGraphicsSceneDrawable drawable = i.next();
-
-        paintDrawableThread(worker, drawable, clipRectangle, preview);
+    // note: the drawables are used in place and not copied: copying a drawable
+    // copies its painter path, its points and its original shapes, which is
+    // by far the most expensive part of iterating them
+    // (paintDrawableThread only reads from the drawable):
+    for (int k=0; k<drawables->length(); k++) {
+        paintDrawableThread(worker, (*drawables)[k], clipRectangle, preview);
     }
 }
 

--- a/src/gui/RGraphicsViewImage.cpp
+++ b/src/gui/RGraphicsViewImage.cpp
@@ -1837,24 +1837,40 @@ void RGraphicsViewImage::paintDrawableThread(RGraphicsViewWorker* worker, RGraph
     }
 
     // painter path:
-    RPainterPath path = drawable.getPainterPath();
-    if (!path.isSane()) {
+    // the path of the drawable is only copied if it has to be transformed:
+    // copying a RPainterPath copies its elements, its points and its original
+    // shapes, and for most drawables neither a pixel unit scale nor an offset
+    // applies. Everything below only reads from the path.
+    const RPainterPath* pathPtr = &drawable.getPainterPath();
+    if (!pathPtr->isSane()) {
         return;
     }
 
-    if (drawable.getPixelUnit() || path.getPixelUnit()) {
-        // path is displayed in pixels, not drawing unit:
-        //RVector sp = path.getStartPoint();
-        RVector sp = path.getBoundingBox().getCenter();
-        path.move(-sp);
-        double dpr = getDevicePixelRatio();
-        double f = 1/factor*dpr;
-        path.scale(f,f);
-        path.move(sp);
+    RPainterPath transformedPath;
+    bool pixelUnit = drawable.getPixelUnit() || pathPtr->getPixelUnit();
+    RVector drawableOffset = drawable.getOffset();
+
+    if (pixelUnit || !drawableOffset.isZero() || !paintOffset.isZero()) {
+        transformedPath = *pathPtr;
+
+        if (pixelUnit) {
+            // path is displayed in pixels, not drawing unit:
+            RVector sp = transformedPath.getBoundingBox().getCenter();
+            transformedPath.move(-sp);
+            double dpr = getDevicePixelRatio();
+            double f = 1/factor*dpr;
+            transformedPath.scale(f,f);
+            transformedPath.move(sp);
+        }
+
+        transformedPath.move(drawableOffset);
+        transformedPath.move(paintOffset);
+
+        pathPtr = &transformedPath;
     }
 
-    path.move(drawable.getOffset());
-    path.move(paintOffset);
+    const RPainterPath& path = *pathPtr;
+
     RBox pathBB = path.getBoundingBox();
 
     // additional bounding box check for painter paths that are


### PR DESCRIPTION
Profiling the traversal of a 100000 line update (after #207) showed no single hot spot left, but allocation churn at ~22% of samples and validity checks at ~11%. Four changes, all in the per drawable path.

## 1. The drawable was copied per drawable

```cpp
RGraphicsSceneDrawable drawable = i.next();     // copy
paintDrawableThread(worker, drawable, clipRectangle, preview);
```

Copying a `RGraphicsSceneDrawable` copies its `RPainterPath`, its points and its original shapes — the largest single item in the profile (~15% of samples). `paintDrawableThread()` only reads from the drawable (all twelve accessors it uses are const, and every data accessor is copied into a local before being modified), so the drawables of the scene are used in place now.

The signature of `paintDrawableThread()` is deliberately unchanged: it is exposed to script.

## 2. The painter path was copied per drawable

The path was copied because it may have to be scaled to pixel units and moved by the drawable offset and the paint offset. For most drawables none of that applies. The copy is now made only when a transformation is actually needed, otherwise the path is used through a `const RPainterPath&`, which also lets the compiler verify that nothing writes to it.

## 3. `RPainterPath::hasPoints()` is const

It modified nothing but was not marked const, which is what blocked using the path through a const reference.

## 4. `RMath::isSane()` and `isNormal()` are inline

They are called for every coordinate of every path of every frame, were out of line, and `isSane()` called `isNaN()` and `isInf()` in turn — several cross translation unit calls per checked coordinate. `std::isfinite` is exactly the condition `!isNaN(v) && !isInf(v)` for all three platform variants of those functions, so `isNaN()` and `isInf()` themselves stay out of line and exported.

## ABI

This removes the exported symbols of `RPainterPath::hasPoints()`, `RMath::isSane()` and `RMath::isNormal()`. The libraries which import them (`qcadentity`, `qcadgui` and `qcadjsapi`) have to be rebuilt.

## Measured

100000 line entities at 2480x1678, all configurations built from source with identical flags, runs interleaved:

| | median full update |
|---|---|
| master | 57.6 ms |
| + no drawable copy | 53.6 ms |
| + conditional path copy | 51.2 ms |
| + const hasPoints, inline isSane | **49.1 ms** |

Master against all four, 5 interleaved rounds:

| | r1 | r2 | r3 | r4 | r5 |
|---|---|---|---|---|---|
| master | 56.4 | 57.8 | 59.6 | 56.9 | 56.8 |
| this PR | 45.3 | 51.9 | 51.3 | 50.6 | 48.2 |

About 7ms, ~12% of a full update. Rendering is unchanged throughout: identical drawing calls for lines (100002 lines / 3 `stroke()`) and for arcs (260002 lines / 7 `stroke()`).

## Also investigated and rejected

- **Colour correction**, a suspect going in: **1.0%** of the traversal samples. Not worth touching.
- Bounding box and visibility checks are 6.2%, but that is genuine culling work with no obvious waste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)