### PR TITLE
REllipse: fix switchMajorMinor, drop recursive correctMajorMinor calls

### DIFF
--- a/src/core/math/REllipse.cpp
+++ b/src/core/math/REllipse.cpp
@@ -310,17 +310,29 @@ void REllipse::setMinorPoint(const RVector& p) {
     setRatio(p.getMagnitude() / getMajorRadius());
 }
 
+/**
+ * Switches the major and the minor axis of this ellipse. The ellipse remains
+ * unchanged, only its representation changes: the ratio is inverted and the
+ * parameters are adjusted accordingly.
+ *
+ * \return False for a ratio of zero or a negative (invalid) ratio.
+ */
 bool REllipse::switchMajorMinor() {
-    if (fabs(ratio) < RS::PointTolerance) {
+    // a negative ratio is invalid:
+    if (ratio < RS::PointTolerance) {
         return false;
     }
     RVector vp_start=getStartPoint();
-    RVector vp_end=getStartPoint();
+    RVector vp_end=getEndPoint();
     RVector vp=getMajorPoint();
-    setMajorPoint(RVector(-ratio*vp.y, ratio*vp.x));
-    setRatio(1.0/ratio);
-    setStartParam(getParamTo(vp_start));
-    setEndParam(getParamTo(vp_end));
+    // the new major point is the current minor point. The attributes are
+    // updated directly: the setters would call correctMajorMinor() which
+    // would undo the switch:
+    majorPoint = RVector(-ratio*vp.y, ratio*vp.x);
+    ratio = 1.0/ratio;
+    // parameters of the two end points in the new parameterization:
+    startParam = getParamTo(vp_start);
+    endParam = getParamTo(vp_end);
     return true;
 }
 
@@ -1200,11 +1212,18 @@ bool REllipse::trimEndPoint(const RVector& trimPoint, const RVector& clickPoint,
     return true;
 }
 
+/**
+ * Makes sure that the major axis of this ellipse is at least as long as its
+ * minor axis by switching the two axes if necessary.
+ */
 void REllipse::correctMajorMinor() {
     if (ratio>1.0) {
+        // the minor point has to be determined before the ratio is inverted.
+        // The attributes are updated directly: the setters would call this
+        // function again:
         RVector mp = getMinorPoint();
         ratio = 1.0/ratio;
-        setMajorPoint(mp);
+        majorPoint = mp;
         startParam = RMath::getNormalizedAngle(startParam - M_PI/2.0);
         endParam = RMath::getNormalizedAngle(endParam - M_PI/2.0);
     }


### PR DESCRIPTION
Fixes [FS#2736](https://www.qcad.org/bugtracker/index.php?do=details&task_id=2736), reported by CVH.

## The report

`correctMajorMinor()` called itself once more through `setMajorPoint()`, and `switchMajorMinor()` called it twice, through `setMajorPoint()` and `setRatio()`. Both now update the attributes directly, as CVH suggested.

## Why it is more than redundancy

For `switchMajorMinor()` the recursion was not merely wasteful. The ratio handed to `setRatio()` is above one whenever the switch is meaningful, so `correctMajorMinor()` swapped the two axes straight back. The function never switched anything — it only negated the major point.

Two further defects in the same function:

- The end point was cached as `getStartPoint()` (a copy/paste of the line above), so the end parameter ended up equal to the start parameter. `isFullEllipse()` treats equal parameters as a full ellipse, so **every arc passed through the function became a full ellipse**.
- The guard used `fabs(ratio)` and therefore accepted a negative ratio, which is invalid and yields a negative minor radius. Also noted by CVH in the report.

## Reachable today

`RShape::getIntersectionPointsEE()` normalizes ellipses whose major radius is shorter than their minor radius through `switchMajorMinor()`, and `REllipse::getTangents()` builds exactly such ellipses by writing `majorPoint` and `ratio` directly. For two of them the reported intersection points were **17.9 units away from both ellipses**; they are now correct.

## Verification

Tested against a build of `qcadcore` with 25 assertions: the axes really switch, start and end point are preserved to 3e-15 and the shape to 1e-14, arcs stay arcs, switching twice is the identity, and a zero or negative ratio is rejected. 11 of the assertions failed before this change, none does now. `correctMajorMinor()` gives bit-identical results with one call instead of two.

Both functions are unchanged since the initial QCAD 3 commit, so this is not a regression from the recent `REllipse` work — and the `ratio > 1` handling added to `getVectorTo()` in #202 already copes with the representation a working `switchMajorMinor()` produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)