### PR TITLE
RCircle: compare the distance to the center with the point tolerance

### DIFF
--- a/src/core/math/RCircle.cpp
+++ b/src/core/math/RCircle.cpp
@@ -246,9 +246,15 @@ RVector RCircle::getPointAtAngle(double a) const {
     return RVector(center.x + cos(a) * radius, center.y + sin(a) * radius, center.z);
 }
 
+/**
+ * \return Distance from \c point to the nearest point on the circle. The
+ *         radius for a point at the center (infinite solutions).
+ *         \c limited and \c strictRange are ignored (circles are unlimited).
+ */
 double RCircle::getDistanceTo(const RVector& point, bool limited, double strictRange) const {
-    // point is at the center of the circle, infinite solutions:
-    if (point.getDistanceTo2D(center) < RS::PointTolerance * RS::PointTolerance) {
+    // point is at the center of the circle, infinite solutions. The same
+    // condition as in getVectorTo(), which returns an invalid vector there:
+    if ((point - center).get2D().getSquaredMagnitude() < RS::PointTolerance * RS::PointTolerance) {
         return radius;
     }
 


### PR DESCRIPTION
Fixes [FS#2734](https://www.qcad.org/bugtracker/index.php?do=details&task_id=2734), reported by CVH, concerning commit 2b1838b.

## The report

`RCircle::getDistanceTo()` compares `RVector::getDistanceTo2D()` — a real distance, `sqrt(x²+y²)` — with `RS::PointTolerance * RS::PointTolerance`, i.e. 1e-18. As CVH puts it, the value should be compared with the tolerance, not with its square.

## What it costs

The special case for a point at the center only triggered for the center itself. Between 1e-18 and 1e-9 away from it the function fell through to `RShape::getDistanceTo()`, which asks `getVectorTo()`. That one applies the same tolerance correctly, returns `RVector::invalid` near the center, and the distance came out as `RNANDOUBLE` — the very case 2b1838b set out to fix.

Measured on a circle with center (10, 20) and radius 5, before this change:

| offset from center | `getDistanceTo()` |
|---|---|
| 0, 1e-18 | 5 (correct) |
| **1e-15, 1e-12, 1e-10** | **NaN** |
| 1e-9 and beyond | correct |

## The change

The condition now uses the squared magnitude, exactly as the adjacent `getVectorTo()` does. That keeps the two functions provably in step, needs no square root, and avoids the question of which side of the comparison to square. RCircle.cpp:251 was the only place in the source where a tolerance was squared without squaring the value compared against it — the four other squared-tolerance comparisons (RLine.cpp:427, RArc.cpp:802, RCircle.cpp:270 and :287) all compare a `getSquaredMagnitude()`.

## Verification

Tested against a build of `qcadcore`: the radius is returned for points 0 to 1e-9 away from the center, `z` is ignored as the comparison is 2D, and ordinary distances (on the circle, inside, outside) are unchanged. 3 of 14 assertions failed before the change, none does now.

## Not addressed here

CVH also suggests adding `RVector::getSquaredMagnitude2D()`, which is a real gap in an otherwise symmetric API (`getMagnitude`, `getSquaredMagnitude`, `getMagnitude2D`, `getDistanceTo2D` all exist). It is left out of this fix because `getSquaredMagnitude` and `getMagnitude2D` are exposed to scripts through generated bindings in this repo and in `qcadjsapi`, so adding it properly means regenerating bindings in two repos. Happy to follow up separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)